### PR TITLE
chore: JWT secret 값 외부 설정으로 분리하여 보안 강화

### DIFF
--- a/aiservice/Dockerfile
+++ b/aiservice/Dockerfile
@@ -1,28 +1,22 @@
-# aiservice/Dockerfile
-FROM eclipse-temurin:21 
-WORKDIR /app # 컨테이너 내에서 작업 디렉토리 설정
+# ---------- 1단계: 빌드 ----------
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /app
 
-# Maven 프로젝트 빌드에 필요한 모든 소스 파일을 컨테이너로 복사
-# 이렇게 하면 Dockerfile 내부에서 Maven 빌드를 수행할 수 있습니다.
-# 먼저 pom.xml을 복사하여 Maven 의존성 레이어를 캐시하는 것이 효율적입니다.
+# 의존성 캐시
 COPY pom.xml .
-RUN mvn dependency:go-offline # 의존성만 미리 다운로드하여 캐시
+RUN mvn dependency:go-offline
 
-# 나머지 소스 코드 복사 (application.yml 포함)
+# 소스 복사 후 빌드
 COPY src ./src
-
-# 애플리케이션 빌드
 RUN mvn clean package -DskipTests
 
-# 빌드된 JAR 파일 복사 (일반적으로 target 디렉토리에 생성됨)
-COPY target/*.jar app.jar
+# ---------- 2단계: 런타임 ----------
+FROM eclipse-temurin:21
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
 
-# Spring Boot 애플리케이션이 사용할 포트 노출
-EXPOSE 8084
-
-# 타임존 설정 (선택 사항이지만 일관성을 위해 유지)
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-# 애플리케이션 실행 명령어
-ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar","--spring.profiles.active=docker"]
+EXPOSE 8084
+ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","app.jar","--spring.profiles.active=docker"]

--- a/author/Dockerfile
+++ b/author/Dockerfile
@@ -1,6 +1,22 @@
-FROM openjdk:15-jdk-alpine
-COPY target/*SNAPSHOT.jar app.jar
-EXPOSE 8080
+# ---------- 1단계: 빌드 ----------
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /app
+
+# 의존성 캐시
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# 소스 복사 후 빌드
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# ---------- 2단계: 런타임 ----------
+FROM eclipse-temurin:21
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar","--spring.profiles.active=docker"]
+
+EXPOSE 8083
+ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","app.jar","--spring.profiles.active=docker"]

--- a/build-docker-compose.yml
+++ b/build-docker-compose.yml
@@ -26,9 +26,11 @@ services:
   user:
     depends_on:
       - kafka
-    image: adoptopenjdk/maven-openjdk11:latest
+    image: laylaoh/user:latest
     environment:
       - SPRING_PROFILES_ACTIVE=docker
+    env_file:
+      - .env
     command: mvn spring-boot:run
     ports:
       - 8082:8082
@@ -57,14 +59,16 @@ services:
     build:
       context: ./aiservice
       dockerfile: Dockerfile
+    env_file:
+      - .env
     ports:
       - 8084:8084
     environment:
       - SPRING_PROFILES_ACTIVE=docker
       - SPRING_GPT_BASE_URL=https://api.openai.com/v1
-      - SPRING_GPT_IMAGE_URL: https://api.openai.com/v1/images/generations
-      - SPRING_GPT_MODEL: gpt-4o-mini
-      - SPRING_GPT_IMAGE_MODEL: dall-e-3
+      - SPRING_GPT_IMAGE_URL=https://api.openai.com/v1/images/generations
+      - SPRING_GPT_MODEL=gpt-4o-mini
+      - SPRING_GPT_IMAGE_MODEL=dall-e-3
       - SPRING_GPT_API_KEY=${SPRING_GPT_API_KEY}
     # networks 설정이 완전히 제거되었습니다.
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,6 +1,22 @@
-FROM openjdk:8u212-jdk-alpine
-COPY target/*SNAPSHOT.jar app.jar
-EXPOSE 8080
+# ---------- 1단계: 빌드 ----------
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /app
+
+# 의존성 캐시
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# 소스 복사 후 빌드
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# ---------- 2단계: 런타임 ----------
+FROM eclipse-temurin:21
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar","--spring.profiles.active=docker"]
+
+EXPOSE 8084
+ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","app.jar","--spring.profiles.active=docker"]

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -1,6 +1,22 @@
-FROM openjdk:15-jdk-alpine
-COPY target/*SNAPSHOT.jar app.jar
-EXPOSE 8080
+# ---------- 1단계: 빌드 ----------
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /app
+
+# 의존성 캐시
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# 소스 복사 후 빌드
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# ---------- 2단계: 런타임 ----------
+FROM eclipse-temurin:21
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar","--spring.profiles.active=docker"]
+
+EXPOSE 8085
+ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","app.jar","--spring.profiles.active=docker"]

--- a/point/Dockerfile
+++ b/point/Dockerfile
@@ -1,6 +1,22 @@
-FROM openjdk:15-jdk-alpine
-COPY target/*SNAPSHOT.jar app.jar
-EXPOSE 8080
+# ---------- 1단계: 빌드 ----------
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /app
+
+# 의존성 캐시
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# 소스 복사 후 빌드
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# ---------- 2단계: 런타임 ----------
+FROM eclipse-temurin:21
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar","--spring.profiles.active=docker"]
+
+EXPOSE 8087
+ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","app.jar","--spring.profiles.active=docker"]

--- a/user/.gitignore
+++ b/user/.gitignore
@@ -10,6 +10,7 @@
 *~
 .#*
 .*.md.html
+.env
 .DS_Store
 .classpath
 .factorypath

--- a/user/Dockerfile
+++ b/user/Dockerfile
@@ -1,6 +1,22 @@
-FROM openjdk:15-jdk-alpine
-COPY target/*SNAPSHOT.jar app.jar
-EXPOSE 8080
+# ---------- 1단계: 빌드 ----------
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /app
+
+# 의존성 캐시
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# 소스 복사 후 빌드
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# ---------- 2단계: 런타임 ----------
+FROM eclipse-temurin:21
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar","--spring.profiles.active=docker"]
+
+EXPOSE 8082
+ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","app.jar","--spring.profiles.active=docker"]

--- a/user/pom.xml
+++ b/user/pom.xml
@@ -98,6 +98,13 @@
 			<version>4.1.3</version>
 			<scope>compile</scope>
 		</dependency>
+
+		<!-- Redis -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/user/pom.xml
+++ b/user/pom.xml
@@ -68,6 +68,10 @@
 			<artifactId>spring-cloud-starter-stream-kafka</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-binder-kafka-streams</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>

--- a/user/src/main/java/aivlecloudnative/application/TokenBlacklistService.java
+++ b/user/src/main/java/aivlecloudnative/application/TokenBlacklistService.java
@@ -1,0 +1,23 @@
+package aivlecloudnative.application;
+
+import java.time.Duration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenBlacklistService {
+
+    private final StringRedisTemplate redis;
+
+    public TokenBlacklistService(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    public void blacklist(String token, long millisToExpire) {
+        redis.opsForValue().set(token, "logout", Duration.ofMillis(millisToExpire));
+    }
+
+    public boolean isBlacklisted(String token) {
+        return redis.hasKey(token);
+    }
+}

--- a/user/src/main/java/aivlecloudnative/application/UserService.java
+++ b/user/src/main/java/aivlecloudnative/application/UserService.java
@@ -34,6 +34,7 @@ public class UserService {
     private final ObjectMapper objectMapper;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Transactional
     public User signUp(SignUpCommand cmd) {
@@ -65,6 +66,12 @@ public class UserService {
 
         // ✅ 토큰 + 사용자 정보 응답
         return new LoginResponse(token, "Bearer", user.getId(), user.getEmail());
+    }
+
+    @Transactional
+    public void logout(String token) {
+        long exp = jwtTokenProvider.getExpiration(token); // 남은 만료 시간(ms)
+        tokenBlacklistService.blacklist(token, exp);
     }
 
     @Transactional

--- a/user/src/main/java/aivlecloudnative/config/kafka/SecurityConfig.java
+++ b/user/src/main/java/aivlecloudnative/config/kafka/SecurityConfig.java
@@ -1,5 +1,6 @@
 package aivlecloudnative.config.kafka;
 
+import aivlecloudnative.application.TokenBlacklistService;
 import aivlecloudnative.infra.JwtAuthenticationFilter;
 import aivlecloudnative.infra.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtProvider;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -38,7 +40,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint((req, res, e) ->
                                 res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")));
 
-        http.addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtProvider, tokenBlacklistService),
                 UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/user/src/main/java/aivlecloudnative/infra/JwtAuthenticationFilter.java
+++ b/user/src/main/java/aivlecloudnative/infra/JwtAuthenticationFilter.java
@@ -6,11 +6,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -27,6 +29,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (jwtProvider.validate(token)) {
                 Authentication auth = jwtProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(auth);
+            } else {
+                log.warn("Invalid JWT token: {}", token);
             }
         }
         chain.doFilter(req, res);

--- a/user/src/main/java/aivlecloudnative/infra/JwtTokenProvider.java
+++ b/user/src/main/java/aivlecloudnative/infra/JwtTokenProvider.java
@@ -58,4 +58,13 @@ public class JwtTokenProvider {
         // 필요하면 roles → GrantedAuthority 변환
         return new UsernamePasswordAuthenticationToken(userId, null, List.of());
     }
+
+    public long getExpiration(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getExpiration().getTime() - System.currentTimeMillis();
+    }
 }

--- a/user/src/main/java/aivlecloudnative/infra/UserController.java
+++ b/user/src/main/java/aivlecloudnative/infra/UserController.java
@@ -6,6 +6,7 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 //<<< Clean Arch / Inbound Adaptor
@@ -27,6 +28,14 @@ public class UserController {
     @PostMapping("/login")
     public LoginResponse login(@RequestBody @Valid LoginCommand cmd) {
         return userService.login(cmd);
+    }
+
+    /* ---------- 로그아웃 ---------- */
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring(7);   // "Bearer " 제거
+        userService.logout(token);
+        return ResponseEntity.ok().build();
     }
 
     /* ---------- 구독 신청 ---------- */

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -50,7 +50,7 @@ server:
 
 # TODO: docker profile에도 추가
 jwt:
-  secret: ${JWT_SECRET}
+  secret: "zM3p7tA9pWxQvYt3eXr0mLb9zD8g7Uu2r4T9xT7zN1sQwXv0vEx2eZr5aE7u5YgK"
 
 ---
 

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -11,6 +11,10 @@ spring:
   config:
     activate:
       on-profile: default
+  data:
+    redis:
+      host: localhost
+      port: 6379
   jpa:
     properties:
       hibernate:
@@ -50,14 +54,17 @@ server:
 
 # TODO: docker profile에도 추가
 jwt:
-  secret: "zM3p7tA9pWxQvYt3eXr0mLb9zD8g7Uu2r4T9xT7zN1sQwXv0vEx2eZr5aE7u5YgK"
-
+  secret: ${JWT_SECRET}
 ---
 
 spring:
   config:
     activate:
       on-profile: docker
+  data:
+    redis:
+      host: localhost
+      port: 6379
   jpa:
     properties:
       hibernate:

--- a/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
+++ b/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.mockito.Mockito.never;
 
 import aivlecloudnative.application.UserService;
 import aivlecloudnative.domain.LoginCommand;
@@ -96,6 +97,33 @@ class UserControllerTest {
                 .andExpect(content().json(objectMapper.writeValueAsString(response)));
 
         Mockito.verify(userService).login(any(LoginCommand.class));
+    }
+
+    // -----------------------------
+    // ✅ 로그아웃 테스트
+    // -----------------------------
+
+    @Test
+    @DisplayName("로그아웃 성공 시 200 응답")
+    void logout_should_return200_when_validToken() throws Exception {
+        String token = "Bearer mock.jwt.token";
+
+        mockMvc.perform(post("/users/logout")
+                        .header("Authorization", token))
+                .andExpect(status().isOk());
+
+        // 실제 토큰 값만 전달되었는지 검증
+        Mockito.verify(userService).logout("mock.jwt.token");
+    }
+
+    @Test
+    @DisplayName("로그아웃 실패 시 400 응답 (Authorization 헤더 누락)")
+    void logout_should_return400_when_noAuthHeader() throws Exception {
+        mockMvc.perform(post("/users/logout"))
+                .andExpect(status().isBadRequest()); // 또는 401로 처리하는 경우엔 isUnauthorized()
+
+        // logout() 호출이 없어야 함
+        Mockito.verify(userService, never()).logout(any());
     }
 
     // -----------------------------

--- a/writing/Dockerfile
+++ b/writing/Dockerfile
@@ -1,6 +1,22 @@
-FROM openjdk:15-jdk-alpine
-COPY target/*SNAPSHOT.jar app.jar
-EXPOSE 8080
+# ---------- 1단계: 빌드 ----------
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /app
+
+# 의존성 캐시
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# 소스 복사 후 빌드
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# ---------- 2단계: 런타임 ----------
+FROM eclipse-temurin:21
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar","--spring.profiles.active=docker"]
+
+EXPOSE 8086
+ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","app.jar","--spring.profiles.active=docker"]


### PR DESCRIPTION
## 🔐 JWT 기반 로그아웃 기능 구현 및 Dockerfile 개선

### 📌 주요 변경사항

---

### ✅ 로그아웃 기능 구현

- **POST** `/users/logout`
- 요청 헤더의 JWT 토큰을 추출하여 **Redis 블랙리스트**에 등록
- 등록 시 토큰의 **남은 만료 시간**을 계산하여 자동 만료되도록 설정
- 블랙리스트에 등록된 토큰으로 요청 시 **인증 거부** 처리 가능

---

### 🧠 블랙리스트 로직

- `TokenBlacklistService` 클래스 생성
- `JwtTokenProvider.getExpiration()`을 통해 남은 유효 시간(ms) 계산
- Redis 저장소에 토큰 키로 저장하며 TTL(Time To Live) 설정

---

### 🧪 테스트 코드 추가

#### `UserServiceTest.java`

- [x] 블랙리스트 등록 메서드 호출 테스트
- [x] JWT 만료 시간 계산 및 저장 로직 테스트

#### `UserControllerTest.java`

- [x] 유효한 토큰으로 로그아웃 요청 시 200 OK 반환
- [x] 잘못된 토큰으로 요청 시 예외 처리 확인

---

### 🐳 Dockerfile 개선

- 기존: 단일 `openjdk` 기반 실행 이미지
- 변경: **멀티 스테이지 빌드**
  - 1단계: `maven` 이미지로 JAR 빌드
  - 2단계: `eclipse-temurin`으로 경량화된 런타임 환경 구성
- 이미지 최적화 및 빌드 속도 개선

---

### 🔐 JWT 시크릿 외부 설정

- 기존: `application.yml`에 `jwt.secret` 직접 명시
- 변경: 환경 변수 `${JWT_SECRET}` 사용으로 **보안 강화**

---

### 📡 호출 예시 (HTTPie 기준)

```bash
http POST http://localhost:8088/users/logout \
  "Authorization: Bearer {accessToken}"
