### PR TITLE
[feat & refactor] 사용자 작가 승인 policy 및 열람 기록 속성명 개선

### DIFF
--- a/user/src/main/java/aivlecloudnative/application/UserService.java
+++ b/user/src/main/java/aivlecloudnative/application/UserService.java
@@ -2,6 +2,7 @@ package aivlecloudnative.application;
 
 import aivlecloudnative.domain.AccessRequestedAsSubscriber;
 import aivlecloudnative.domain.AccessRequestedWithPoints;
+import aivlecloudnative.domain.AuthorAccepted;
 import aivlecloudnative.domain.BookViewed;
 import aivlecloudnative.domain.LoginCommand;
 import aivlecloudnative.domain.LoginResponse;
@@ -67,7 +68,13 @@ public class UserService {
         String token = jwtTokenProvider.createToken(user.getId(), List.of("ROLE_USER"));
 
         // ✅ 토큰 + 사용자 정보 응답
-        return new LoginResponse(token, "Bearer", user.getId(), user.getEmail());
+        return new LoginResponse(
+                token,
+                "Bearer",
+                user.getId(),
+                user.getEmail(),
+                user.getIsAuthor()
+        );
     }
 
     @Transactional
@@ -145,5 +152,8 @@ public class UserService {
         User user = findUserByIdOrThrow(id);
 
         return user.getHasActiveSubscription();
+    }
+
+    public void authorApproved(AuthorAccepted authorAccepted) {
     }
 }

--- a/user/src/main/java/aivlecloudnative/application/UserService.java
+++ b/user/src/main/java/aivlecloudnative/application/UserService.java
@@ -12,6 +12,7 @@ import aivlecloudnative.domain.RequestContentAccessCommand;
 import aivlecloudnative.domain.RequestSubscriptionCommand;
 import aivlecloudnative.domain.SignUpCommand;
 import aivlecloudnative.domain.User;
+import aivlecloudnative.domain.UserInfoResponse;
 import aivlecloudnative.domain.UserRepository;
 import aivlecloudnative.domain.UserSignedUp;
 import aivlecloudnative.domain.UserSubscribed;
@@ -154,6 +155,25 @@ public class UserService {
         return user.getHasActiveSubscription();
     }
 
+    @Transactional
     public void authorApproved(AuthorAccepted authorAccepted) {
+        Long userId = authorAccepted.getId();
+
+        User user = findUserByIdOrThrow(userId);
+        user.setIsAuthor(true);
+
+        // 변경사항 저장 (JPA 엔티티이므로 트랜잭션 내에서 dirty checking으로 자동 반영됨)
+    }
+
+    public UserInfoResponse getUserInfo(Long id) {
+        User user = findUserByIdOrThrow(id);
+        return new UserInfoResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getIsKt(),
+                user.getIsAuthor(),
+                user.getHasActiveSubscription(),
+                user.getMyBookHistory()
+        );
     }
 }

--- a/user/src/main/java/aivlecloudnative/domain/AuthorAccepted.java
+++ b/user/src/main/java/aivlecloudnative/domain/AuthorAccepted.java
@@ -1,0 +1,19 @@
+package aivlecloudnative.domain;
+
+import aivlecloudnative.infra.AbstractEvent;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = false)
+@Data
+@ToString
+public class AuthorAccepted extends AbstractEvent {
+
+    private Long id;
+
+    public AuthorAccepted(Long id) {
+        this.id = id;
+    }
+}
+

--- a/user/src/main/java/aivlecloudnative/domain/BookViewed.java
+++ b/user/src/main/java/aivlecloudnative/domain/BookViewed.java
@@ -7,15 +7,16 @@ import lombok.*;
 @ToString
 public class BookViewed extends AbstractEvent {
 
-    private Long userId;
     private Long bookId;
-
     private String title;
     private String authorName;
     private String summary;
     private String category;
     private String coverImageUrl;
     private String ebookUrl;
-    private String subscriptionFee;
-    private String viewCount;
+    private String price;
+    private Long totalViewCount;
+    private Long personalViewCount;
+    private Long userId;
 }
+

--- a/user/src/main/java/aivlecloudnative/domain/LoginResponse.java
+++ b/user/src/main/java/aivlecloudnative/domain/LoginResponse.java
@@ -4,5 +4,6 @@ public record LoginResponse(
         String accessToken,
         String tokenType,
         Long userId,
-        String email
+        String email,
+        boolean isAuthor
 ) {}

--- a/user/src/main/java/aivlecloudnative/domain/User.java
+++ b/user/src/main/java/aivlecloudnative/domain/User.java
@@ -27,7 +27,7 @@ public class User {
 
     private String userName;
 
-    private Boolean hasActiveSubscription;
+    private Boolean hasActiveSubscription = false;
 
     private String message;
 
@@ -40,7 +40,7 @@ public class User {
 
     private String password;
 
-    private Boolean isAuthor;
+    private Boolean isAuthor = false;
 
     public static UserRepository repository() {
         return UserApplication.applicationContext.getBean(
@@ -52,8 +52,6 @@ public class User {
         this.userName = signUpCommand.getUserName();
         this.email = signUpCommand.getEmail();
         this.isKt = signUpCommand.getIsKt();
-        this.hasActiveSubscription = false;
-        this.isAuthor = false;
     }
 
     public void addBookToHistory(Long bookId) {

--- a/user/src/main/java/aivlecloudnative/domain/User.java
+++ b/user/src/main/java/aivlecloudnative/domain/User.java
@@ -40,6 +40,8 @@ public class User {
 
     private String password;
 
+    private Boolean isAuthor;
+
     public static UserRepository repository() {
         return UserApplication.applicationContext.getBean(
             UserRepository.class
@@ -51,6 +53,7 @@ public class User {
         this.email = signUpCommand.getEmail();
         this.isKt = signUpCommand.getIsKt();
         this.hasActiveSubscription = false;
+        this.isAuthor = false;
     }
 
     public void addBookToHistory(Long bookId) {

--- a/user/src/main/java/aivlecloudnative/domain/UserInfoResponse.java
+++ b/user/src/main/java/aivlecloudnative/domain/UserInfoResponse.java
@@ -1,0 +1,12 @@
+package aivlecloudnative.domain;
+
+import java.util.List;
+
+public record UserInfoResponse(
+        Long id,
+        String email,
+        boolean isKT,
+        boolean isAuthor,
+        boolean hasActiveSubscription,
+        List<Long> contentHistory
+) {}

--- a/user/src/main/java/aivlecloudnative/domain/UserSignedUp.java
+++ b/user/src/main/java/aivlecloudnative/domain/UserSignedUp.java
@@ -14,6 +14,7 @@ public class UserSignedUp extends AbstractEvent {
     private String userName;
     private String message;
     private Boolean isKt;
+    private Boolean isAuthor;
 
     public UserSignedUp(User aggregate) {
         super(aggregate);
@@ -23,6 +24,7 @@ public class UserSignedUp extends AbstractEvent {
         this.email = aggregate.getEmail();
         this.userName = aggregate.getUserName();
         this.isKt = aggregate.getIsKt();
+        this.isAuthor = aggregate.getIsAuthor();
     }
 
     public UserSignedUp() {

--- a/user/src/main/java/aivlecloudnative/infra/OutboxPublisher.java
+++ b/user/src/main/java/aivlecloudnative/infra/OutboxPublisher.java
@@ -24,7 +24,6 @@ public class OutboxPublisher {
     @Scheduled(fixedDelay = 3000)
     @Transactional
     public void publishEvents() {
-        log.info("🟢 OutboxPublisher 스케줄러 실행됨");
         List<OutboxMessage> messages = outboxRepo.findByStatusOrderByCreatedAtAsc(OutboxMessage.PublishStatus.READY);
 
         for (OutboxMessage msg : messages) {

--- a/user/src/main/java/aivlecloudnative/infra/PolicyHandler.java
+++ b/user/src/main/java/aivlecloudnative/infra/PolicyHandler.java
@@ -1,6 +1,7 @@
 package aivlecloudnative.infra;
 
 import aivlecloudnative.application.UserService;
+import aivlecloudnative.domain.AuthorAccepted;
 import aivlecloudnative.domain.BookViewed;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -21,4 +22,13 @@ public class PolicyHandler {
             userService.updateBookRead(bookViewed);
         };
     }
+
+    @Bean
+    public Consumer<AuthorAccepted> authorApproved() {
+        return authorAccepted -> {
+            System.out.println("##### listener AuthorApproved : " + authorAccepted);
+            userService.authorApproved(authorAccepted);
+        };
+    }
+
 }

--- a/user/src/main/java/aivlecloudnative/infra/UserController.java
+++ b/user/src/main/java/aivlecloudnative/infra/UserController.java
@@ -61,5 +61,12 @@ public class UserController {
     public List<Long> getContentHistories(@PathVariable Long id) {
         return userService.getContentHistory(id);
     }
+
+    /* ---------- 사용자 정보 조회 ---------- */
+    @GetMapping("/{id}")
+    public UserInfoResponse getUserInfo(@PathVariable Long id) {
+        return userService.getUserInfo(id);
+    }
 }
+
 //>>> Clean Arch / Inbound Adaptor

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -23,15 +23,21 @@ spring:
         implicit_naming_strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyComponentPathImpl
   cloud:
     function:
-      definition: updateBookRead
+      definition: updateBookRead;authorApproved
     stream:
       default:
         contentType: application/json
       bindings:
         updateBookRead-in-0:
           destination: aivlecloudnative
-          group: user
+          group: user-update-book
           contentType: application/json
+
+        authorApproved-in-0:
+          destination: aivlecloudnative
+          group: user-author-approved
+          contentType: application/json
+
         event-out:
           destination: aivlecloudnative
           contentType: application/json
@@ -49,9 +55,9 @@ spring:
 
 logging:
   level:
-    org.hibernate.type: trace
+    org.hibernate: info
     org.springframework.cloud: debug
-    aivlecloudnative.infra.OutboxPublisher: info
+    aivlecloudnative.infra.OutboxPublisher: warn
 
 server:
   port: 8082
@@ -77,13 +83,21 @@ spring:
         implicit_naming_strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyComponentPathImpl
   cloud:
     function:
-      definition: updateBookRead
+      definition: updateBookRead;authorApproved
     stream:
+      default:
+        contentType: application/json
       bindings:
         updateBookRead-in-0:
           destination: aivlecloudnative
-          group: user
+          group: user-update-book
           contentType: application/json
+
+        authorApproved-in-0:
+          destination: aivlecloudnative
+          group: user-author-approved
+          contentType: application/json
+
         event-out:
           destination: aivlecloudnative
           contentType: application/json

--- a/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
+++ b/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
@@ -85,7 +85,13 @@ class UserControllerTest {
         cmd.setEmail("user@example.com");
         cmd.setPassword("1234");
 
-        LoginResponse response = new LoginResponse("mock-token", "Bearer", 1L, "user@example.com");
+        LoginResponse response = new LoginResponse(
+                "mock-token",
+                "Bearer",
+                1L,
+                "user@example.com",
+                false
+        );
 
         Mockito.when(userService.login(any(LoginCommand.class)))
                 .thenReturn(response);

--- a/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
+++ b/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
@@ -14,6 +14,7 @@ import aivlecloudnative.domain.RequestContentAccessCommand;
 import aivlecloudnative.domain.RequestSubscriptionCommand;
 import aivlecloudnative.domain.SignUpCommand;
 import aivlecloudnative.domain.User;
+import aivlecloudnative.domain.UserInfoResponse;
 import aivlecloudnative.infra.UserController;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -235,4 +236,26 @@ class UserControllerTest {
 
         Mockito.verify(userService).getContentHistory(1L);
     }
+
+    @Test
+    @DisplayName("사용자 정보 조회 성공 시 200과 JSON 반환")
+    void getUserInfo_should_return200_and_json() throws Exception {
+        UserInfoResponse dto = new UserInfoResponse(
+                1L,
+                "user@example.com",
+                true,
+                true,
+                true,
+                List.of(2L, 5L)
+        );
+
+        Mockito.when(userService.getUserInfo(1L)).thenReturn(dto);
+
+        mockMvc.perform(get("/users/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(dto)));
+
+        Mockito.verify(userService).getUserInfo(1L);
+    }
+
 }

--- a/user/src/test/java/aivlecloudnative/signUp/UserServiceTest.java
+++ b/user/src/test/java/aivlecloudnative/signUp/UserServiceTest.java
@@ -1,245 +1,287 @@
-        package aivlecloudnative.signUp;
+package aivlecloudnative.signUp;
 
-        import aivlecloudnative.application.TokenBlacklistService;
-        import aivlecloudnative.application.UserService;
-        import aivlecloudnative.domain.*;
-        import aivlecloudnative.infra.JwtTokenProvider;
-        import com.fasterxml.jackson.databind.ObjectMapper;
-        import org.junit.jupiter.api.Assertions;
-        import org.junit.jupiter.api.BeforeEach;
-        import org.junit.jupiter.api.DisplayName;
-        import org.junit.jupiter.api.Test;
-        import org.junit.jupiter.api.extension.ExtendWith;
-        import org.mockito.Mock;
-        import org.mockito.junit.jupiter.MockitoExtension;
-        import org.springframework.security.crypto.password.PasswordEncoder;
+import aivlecloudnative.application.TokenBlacklistService;
+import aivlecloudnative.application.UserService;
+import aivlecloudnative.domain.*;
+import aivlecloudnative.infra.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
-        import java.util.*;
+import java.util.*;
 
-        import static org.junit.Assert.*;
-        import static org.mockito.ArgumentMatchers.*;
-        import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
-        @ExtendWith(MockitoExtension.class)
-        public class UserServiceTest {
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
 
-            @Mock
-            private UserRepository userRepository;
+    @Mock
+    private UserRepository userRepository;
 
-            @Mock
-            private OutboxMessageRepository outboxMessageRepository;
+    @Mock
+    private OutboxMessageRepository outboxMessageRepository;
 
-            @Mock
-            private PasswordEncoder passwordEncoder;
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
-            @Mock
-            private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
 
-            @Mock
-            private TokenBlacklistService tokenBlacklistService;
+    @Mock
+    private TokenBlacklistService tokenBlacklistService;
 
-            private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-            private UserService userService;
+    private UserService userService;
 
-            @BeforeEach
-            void setUp() {
-                userService = new UserService(
-                        userRepository,
-                        outboxMessageRepository,
-                        objectMapper,
-                        passwordEncoder,
-                        jwtTokenProvider,
-                        tokenBlacklistService
-                );
-            }
+    @BeforeEach
+    void setUp() {
+        userService = new UserService(
+                userRepository,
+                outboxMessageRepository,
+                objectMapper,
+                passwordEncoder,
+                jwtTokenProvider,
+                tokenBlacklistService
+        );
+    }
 
-            @Test
-            @DisplayName("회원가입 시 이메일 중복이면 실패")
-            void signUp_shouldThrow_ifEmailExists() {
-                SignUpCommand cmd = new SignUpCommand();
-                cmd.setEmail("test@example.com");
+    @Test
+    @DisplayName("회원가입 시 이메일 중복이면 실패")
+    void signUp_shouldThrow_ifEmailExists() {
+        SignUpCommand cmd = new SignUpCommand();
+        cmd.setEmail("test@example.com");
 
-                when(userRepository.existsByEmail(cmd.getEmail())).thenReturn(true);
+        when(userRepository.existsByEmail(cmd.getEmail())).thenReturn(true);
 
-                assertThrows(IllegalArgumentException.class, () -> userService.signUp(cmd));
-            }
+        assertThrows(IllegalArgumentException.class, () -> userService.signUp(cmd));
+    }
 
-            @Test
-            @DisplayName("회원가입 성공 시 비밀번호 암호화 및 Outbox 저장")
-            void signUp_shouldEncodePassword_andSaveOutbox() {
-                SignUpCommand cmd = new SignUpCommand();
-                cmd.setEmail("user@example.com");
-                cmd.setUserName("홍길동");
-                cmd.setPassword("plain1234");
-                cmd.setIsKt(true);
+    @Test
+    @DisplayName("회원가입 성공 시 비밀번호 암호화 및 Outbox 저장")
+    void signUp_shouldEncodePassword_andSaveOutbox() {
+        SignUpCommand cmd = new SignUpCommand();
+        cmd.setEmail("user@example.com");
+        cmd.setUserName("홍길동");
+        cmd.setPassword("plain1234");
+        cmd.setIsKt(true);
 
-                when(userRepository.existsByEmail(any())).thenReturn(false);
-                when(passwordEncoder.encode(cmd.getPassword())).thenReturn("encoded1234");
-                when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(userRepository.existsByEmail(any())).thenReturn(false);
+        when(passwordEncoder.encode(cmd.getPassword())).thenReturn("encoded1234");
+        when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-                User saved = userService.signUp(cmd);
+        User saved = userService.signUp(cmd);
 
-                Assertions.assertEquals("encoded1234", saved.getPassword());
-                verify(outboxMessageRepository).save(any(OutboxMessage.class));
-            }
+        Assertions.assertEquals("encoded1234", saved.getPassword());
+        verify(outboxMessageRepository).save(any(OutboxMessage.class));
+    }
 
-            @Test
-            @DisplayName("로그인 성공 시 JWT 포함 LoginResponse 반환")
-            void login_shouldReturnToken_whenCredentialsMatch() {
-                String rawPassword = "plain1234";
-                String encodedPassword = "encoded1234";
-                String fakeToken = "jwt.token.string";
+    @Test
+    @DisplayName("로그인 성공 시 JWT 포함 LoginResponse 반환")
+    void login_shouldReturnToken_whenCredentialsMatch() {
+        String rawPassword = "plain1234";
+        String encodedPassword = "encoded1234";
+        String fakeToken = "jwt.token.string";
 
-                User user = new User();
-                user.setId(1L);
-                user.setEmail("user@example.com");
-                user.setPassword(encodedPassword);
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("user@example.com");
+        user.setPassword(encodedPassword);
 
-                LoginCommand cmd = new LoginCommand();
-                cmd.setEmail("user@example.com");
-                cmd.setPassword(rawPassword);
+        LoginCommand cmd = new LoginCommand();
+        cmd.setEmail("user@example.com");
+        cmd.setPassword(rawPassword);
 
-                when(userRepository.findByEmail(cmd.getEmail())).thenReturn(Optional.of(user));
-                when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
-                when(jwtTokenProvider.createToken(eq(user.getId()), any())).thenReturn(fakeToken);
+        when(userRepository.findByEmail(cmd.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+        when(jwtTokenProvider.createToken(eq(user.getId()), any())).thenReturn(fakeToken);
 
-                LoginResponse response = userService.login(cmd);
+        LoginResponse response = userService.login(cmd);
 
-                Assertions.assertEquals(fakeToken, response.accessToken());
-                Assertions.assertEquals("Bearer", response.tokenType());
-                Assertions.assertEquals(user.getId(), response.userId());
-                Assertions.assertEquals(user.getEmail(), response.email());
+        Assertions.assertEquals(fakeToken, response.accessToken());
+        Assertions.assertEquals("Bearer", response.tokenType());
+        Assertions.assertEquals(user.getId(), response.userId());
+        Assertions.assertEquals(user.getEmail(), response.email());
 
-                verify(jwtTokenProvider).createToken(eq(user.getId()), any());
-            }
+        verify(jwtTokenProvider).createToken(eq(user.getId()), any());
+    }
 
-            @Test
-            @DisplayName("로그인 실패 - 이메일 없음")
-            void login_shouldThrow_ifUserNotFound() {
-                LoginCommand cmd = new LoginCommand();
-                cmd.setEmail("missing@example.com");
-                cmd.setPassword("1234");
+    @Test
+    @DisplayName("로그인 실패 - 이메일 없음")
+    void login_shouldThrow_ifUserNotFound() {
+        LoginCommand cmd = new LoginCommand();
+        cmd.setEmail("missing@example.com");
+        cmd.setPassword("1234");
 
-                when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
 
-                assertThrows(IllegalArgumentException.class, () -> userService.login(cmd));
-            }
+        assertThrows(IllegalArgumentException.class, () -> userService.login(cmd));
+    }
 
-            @Test
-            @DisplayName("로그인 실패 - 비밀번호 불일치")
-            void login_shouldThrow_ifPasswordIncorrect() {
-                LoginCommand cmd = new LoginCommand();
-                cmd.setEmail("user@example.com");
-                cmd.setPassword("wrongpass");
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 불일치")
+    void login_shouldThrow_ifPasswordIncorrect() {
+        LoginCommand cmd = new LoginCommand();
+        cmd.setEmail("user@example.com");
+        cmd.setPassword("wrongpass");
 
-                User user = new User();
-                user.setEmail("user@example.com");
-                user.setPassword("encodedpass");
+        User user = new User();
+        user.setEmail("user@example.com");
+        user.setPassword("encodedpass");
 
-                when(userRepository.findByEmail(cmd.getEmail())).thenReturn(Optional.of(user));
-                when(passwordEncoder.matches(cmd.getPassword(), user.getPassword())).thenReturn(false);
+        when(userRepository.findByEmail(cmd.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(cmd.getPassword(), user.getPassword())).thenReturn(false);
 
-                assertThrows(IllegalArgumentException.class, () -> userService.login(cmd));
-            }
+        assertThrows(IllegalArgumentException.class, () -> userService.login(cmd));
+    }
 
-            @Test
-            @DisplayName("로그아웃 시 토큰이 블랙리스트에 남은 만료시간으로 등록된다")
-            void logout_shouldBlacklistToken_withRemainingExpiration() {
-                // given
-                String token = "jwt.token.string";
-                long remainMs = 30 * 60 * 1000L; // 30분 남았다고 가정
+    @Test
+    @DisplayName("로그아웃 시 토큰이 블랙리스트에 남은 만료시간으로 등록된다")
+    void logout_shouldBlacklistToken_withRemainingExpiration() {
+        // given
+        String token = "jwt.token.string";
+        long remainMs = 30 * 60 * 1000L; // 30분 남았다고 가정
 
-                when(jwtTokenProvider.getExpiration(token)).thenReturn(remainMs);
+        when(jwtTokenProvider.getExpiration(token)).thenReturn(remainMs);
 
-                // when
-                userService.logout(token);
+        // when
+        userService.logout(token);
 
-                // then
-                verify(tokenBlacklistService).blacklist(token, remainMs);
-            }
+        // then
+        verify(tokenBlacklistService).blacklist(token, remainMs);
+    }
 
-            @Test
-            @DisplayName("KT 유저 열람 신청 시 이벤트 저장")
-            void requestContentAccess_shouldSaveKtEvent() {
-                User user = new User();
-                user.setId(1L);
-                user.setIsKt(true);
+    @Test
+    @DisplayName("KT 유저 열람 신청 시 이벤트 저장")
+    void requestContentAccess_shouldSaveKtEvent() {
+        User user = new User();
+        user.setId(1L);
+        user.setIsKt(true);
+        user.setHasActiveSubscription(true);
 
-                RequestContentAccessCommand cmd = new RequestContentAccessCommand();
-                cmd.setUserId(1L);
-                cmd.setBookId(2L);
+        RequestContentAccessCommand cmd = new RequestContentAccessCommand();
+        cmd.setUserId(1L);
+        cmd.setBookId(2L);
 
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-                when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-                userService.requestContentAccess(cmd);
+        userService.requestContentAccess(cmd);
 
-                verify(outboxMessageRepository).save(argThat(msg -> msg.getEventType().equals("AccessRequestedAsSubscriber")));
-            }
+        verify(outboxMessageRepository).save(argThat(msg -> msg.getEventType().equals("AccessRequestedAsSubscriber")));
+    }
 
-            @Test
-            @DisplayName("비 KT 유저 열람 신청 시 이벤트 저장")
-            void requestContentAccess_shouldSavePointEvent() {
-                User user = new User();
-                user.setId(1L);
-                user.setIsKt(false);
+    @Test
+    @DisplayName("비 KT 유저 열람 신청 시 이벤트 저장")
+    void requestContentAccess_shouldSavePointEvent() {
+        User user = new User();
+        user.setId(1L);
+        user.setIsKt(false);
 
-                RequestContentAccessCommand cmd = new RequestContentAccessCommand();
-                cmd.setUserId(1L);
-                cmd.setBookId(2L);
+        RequestContentAccessCommand cmd = new RequestContentAccessCommand();
+        cmd.setUserId(1L);
+        cmd.setBookId(2L);
 
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-                when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-                userService.requestContentAccess(cmd);
+        userService.requestContentAccess(cmd);
 
-                verify(outboxMessageRepository).save(argThat(msg -> msg.getEventType().equals("AccessRequestedWithPoints")));
-            }
+        verify(outboxMessageRepository).save(argThat(msg -> msg.getEventType().equals("AccessRequestedWithPoints")));
+    }
 
-            @Test
-            @DisplayName("독서 기록 추가")
-            void updateBookRead_shouldAddBookToHistory() {
-                User user = new User();
-                user.setId(1L);
-                user.setMyBookHistory(new ArrayList<>());
+    @Test
+    @DisplayName("독서 기록 추가")
+    void updateBookRead_shouldAddBookToHistory() {
+        User user = new User();
+        user.setId(1L);
+        user.setMyBookHistory(new ArrayList<>());
 
-                BookViewed event = new BookViewed();
-                event.setUserId(1L);
-                event.setBookId(42L);
+        BookViewed event = new BookViewed();
+        event.setUserId(1L);
+        event.setBookId(42L);
 
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-                when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-                userService.updateBookRead(event);
+        userService.updateBookRead(event);
 
-                Assertions.assertTrue(user.getMyBookHistory().contains(42L));
-                verify(userRepository).save(user);
-            }
+        Assertions.assertTrue(user.getMyBookHistory().contains(42L));
+        verify(userRepository).save(user);
+    }
 
-            @Test
-            @DisplayName("구독 상태 조회")
-            void getSubscriptionStatus_shouldReturnCorrectValue() {
-                User user = new User();
-                user.setHasActiveSubscription(true);
+    @Test
+    @DisplayName("구독 상태 조회")
+    void getSubscriptionStatus_shouldReturnCorrectValue() {
+        User user = new User();
+        user.setHasActiveSubscription(true);
 
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
-                boolean result = userService.getSubscriptionStatus(1L);
-                Assertions.assertTrue(result);
-            }
+        boolean result = userService.getSubscriptionStatus(1L);
+        Assertions.assertTrue(result);
+    }
 
-            @Test
-            @DisplayName("열람 내역 조회")
-            void getContentHistory_shouldReturnHistory() {
-                User user = new User();
-                user.setMyBookHistory(List.of(1L, 2L, 3L));
+    @Test
+    @DisplayName("열람 내역 조회")
+    void getContentHistory_shouldReturnHistory() {
+        User user = new User();
+        user.setMyBookHistory(List.of(1L, 2L, 3L));
 
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
-                List<Long> result = userService.getContentHistory(1L);
+        List<Long> result = userService.getContentHistory(1L);
 
-                Assertions.assertEquals(3, result.size());
-                Assertions.assertTrue(result.contains(2L));
-            }
-        }
+        Assertions.assertEquals(3, result.size());
+        Assertions.assertTrue(result.contains(2L));
+    }
+
+    @Test
+    @DisplayName("작가 승인 이벤트 처리 시 isAuthor=true로 변경")
+    void authorApproved_should_setIsAuthorTrue() {
+        // given
+        User user = new User();
+        user.setId(1L);
+        user.setIsAuthor(false);
+
+        AuthorAccepted event = new AuthorAccepted(1L);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when
+        userService.authorApproved(event);
+
+        // then
+        Assertions.assertTrue(user.getIsAuthor());
+        verify(userRepository).findById(1L);
+    }
+
+    @Test
+    @DisplayName("getUserInfo()는 UserInfoResponse를 반환한다")
+    void getUserInfo_should_return_dto() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("dto@example.com");
+        user.setIsKt(true);
+        user.setIsAuthor(false);
+        user.setHasActiveSubscription(false);
+        user.setMyBookHistory(List.of(10L, 11L));
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        UserInfoResponse dto = userService.getUserInfo(1L);
+
+        Assertions.assertEquals("dto@example.com", dto.email());
+        Assertions.assertTrue(dto.isKT());
+        Assertions.assertEquals(List.of(10L, 11L), dto.contentHistory());
+    }
+
+}


### PR DESCRIPTION
## 🧑‍💼 사용자 작가 승인 policy 및 열람 기록 속성명 개선

## 📌 주요 변경사항

### ✅ 사용자 작가 승인 로직 및 Policy 구현
- `User` 도메인에 `isAuthor` Boolean 필드 추가
- 작가 승인 시 `AuthorAccepted` 이벤트 발행 - 작가 관리 도메인에서
- `UserService.approveAuthor()` 메서드로 작가 승인 처리

---

### 🧪 테스트 추가
- `UserServiceTest`: 작가 승인 시 이벤트 발행 확인

---

### 📘 도서 열람 기록 처리 개선
- SubscriptionFee → price
- viewCount → totalViewCount, personalViewCount
