### PR TITLE
[feat] 마이페이지 UI 구성 및 작가용 원고 관리 기능 구현

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { AuthProvider } from "./context/AuthContext";
 
 import MainPage from "./pages/MainPage";
 import { LoginPage, SignUpPage } from "./pages/AuthPages";
@@ -8,6 +7,7 @@ import MyPage from "./pages/MyPage";
 import ManuscriptEditor from "./pages/ManuscriptEditor";
 import AllBooksPage from "./pages/AllBooksPage";
 import BookDetail from "./pages/BookDetail";
+import ManuscriptList from "./pages/ManuscriptList";
 
 function App() {
     return (
@@ -17,7 +17,9 @@ function App() {
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/signup" element={<SignUpPage />} />
                 <Route path="/mypage" element={<MyPage />} />
-                <Route path="/manuscript" element={<ManuscriptEditor />} />
+                <Route path="/manuscriptList" element={<ManuscriptList />} />
+                <Route path="/manuscript/:authorId/new" element={<ManuscriptEditor />} />
+                <Route path="/manuscript/:authorId/:manuscriptId" element={<ManuscriptEditor />} />
                 <Route path="/books" element={<AllBooksPage />} />
                 <Route path="/book/:id" element={<BookDetail />} />
             </Routes>

--- a/frontend/src/components/AppHeader.js
+++ b/frontend/src/components/AppHeader.js
@@ -10,6 +10,7 @@ export default function AppHeader() {
     const { isLoggedIn, isAuthor, logout } = useAuth();
 
     const showBackButton = location.pathname !== "/";
+    const hideManuscriptButton = location.pathname.startsWith("/manuscriptList");
 
     const handleLogout = () => {
         logout();
@@ -32,8 +33,8 @@ export default function AppHeader() {
                 {isLoggedIn ? (
                     <>
                         <Button onClick={() => navigate("/mypage")}>마이페이지</Button>
-                        {isAuthor && (
-                            <Button onClick={() => navigate("/manuscript")}>원고 등록</Button>
+                        {isAuthor && !hideManuscriptButton && (
+                            <Button onClick={() => navigate("/manuscriptList")}>원고 조회</Button>
                         )}
                         <Button variant="ghost" onClick={handleLogout}>로그아웃</Button>
                     </>

--- a/frontend/src/components/ui/button.js
+++ b/frontend/src/components/ui/button.js
@@ -9,7 +9,7 @@ const buttonVariants = cva(
             variant: {
                 default: "bg-sky-500 text-white hover:bg-sky-100 hover:text-gray-900",
                 secondary: "bg-sky-700 text-gray-900 hover:bg-gray-300",
-                ghost: "bg-transparent hover:bg-gray-100",
+                ghost: "bg-transparent hover:bg-gray-100 hover:text-gray-900",
             },
         },
         defaultVariants: { variant: "default" },

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -51,7 +51,7 @@ export function AuthProvider({ children }) {
             console.log(data);
 
             const userInfo = {
-                token: data.token,
+                token: data.accessToken,
                 tokenType: data.tokenType,
                 userId: data.userId,
                 email: data.email,

--- a/frontend/src/lib/statusUtils.js
+++ b/frontend/src/lib/statusUtils.js
@@ -1,0 +1,12 @@
+export const getStatusLabel = (status) => {
+    switch (status) {
+        case "PUBLICATION_REQUESTED":
+            return "출간 요청 완료";
+        case "REGISTERED":
+            return "임시 저장됨";
+        case "AutoPublished":
+            return "자동출판됨";
+        default:
+            return status ?? "-";
+    }
+};

--- a/frontend/src/pages/ManuscriptEditor.js
+++ b/frontend/src/pages/ManuscriptEditor.js
@@ -1,53 +1,122 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 import { Card, CardContent, CardHeader } from "../components/ui/card";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Textarea } from "../components/ui/textarea";
-import { Loader2, CheckCircle2, UploadCloud } from "lucide-react";
+import { Loader2, CheckCircle2 } from "lucide-react";
 import { motion } from "framer-motion";
+import BackButton from "../components/ui/backButton";
+import {getStatusLabel} from "../lib/statusUtils";
 
-/**
- * 원고 작성/수정 화면
- * - 제목, 본문, 파일 첨부(선택) 입력
- * - "저장"  : 임시 저장 API 호출
- * - "출간 요청": 출간 요청 API 호출
- */
 export default function ManuscriptEditor() {
+    const { authorId, manuscriptId } = useParams();
+    const isEdit = manuscriptId && manuscriptId !== "new";
+    const { user } = useAuth();
+    const navigate = useNavigate();
+    const API_BASE = process.env.REACT_APP_API_URL;
+
     const [title, setTitle] = useState("");
     const [body, setBody] = useState("");
-    const [file, setFile] = useState(null);
-    // "idle" | "saving" | "saved" | "publishing" | "published"
     const [status, setStatus] = useState("idle");
 
-    /** 파일 선택 */
-    const handleFileChange = (e) => {
-        if (e.target.files?.[0]) {
-            setFile(e.target.files[0]);
-        }
-    };
+    const [authorName, setAuthorName] = useState(user?.username ?? "");
+    const [statusText, setStatusText] = useState("");
+    const [lastModifiedAt, setLastModifiedAt] = useState("");
+    const [summary, setSummary] = useState("");
+    const [keywords, setKeywords] = useState("");
 
-    /** 원고 임시 저장 */
+    useEffect(() => {
+        if (!isEdit) return;
+
+        const fetchDetail = async () => {
+            try {
+                const res = await fetch(`${API_BASE}/manuscripts/${authorId}/${manuscriptId}`, {
+                    headers: {
+                        Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
+                    },
+                });
+                if (!res.ok) throw new Error("원고를 불러올 수 없습니다.");
+                const data = await res.json();
+                setTitle(data.title);
+                setBody(data.content);
+                setAuthorName(data.authorName);
+                setStatusText(data.status);
+                setLastModifiedAt(data.lastModifiedAt);
+                setSummary(data.summary ?? "");
+                setKeywords(data.keywords ?? "");
+            } catch (e) {
+                alert(e.message);
+            }
+        };
+
+        fetchDetail();
+    }, [authorId, manuscriptId, isEdit, API_BASE, user]);
+
     const handleSave = async () => {
         setStatus("saving");
         try {
-            // TODO: saveDraft(title, body, file)
-            await new Promise((r) => setTimeout(r, 1500));
+            const url = isEdit
+                ? `${API_BASE}/manuscripts/${manuscriptId}/save`
+                : `${API_BASE}/manuscripts/registration`;
+
+            const method = isEdit ? "PUT" : "POST";
+
+            const payload = {
+                authorId: user.userId,
+                title,
+                content: body,
+                summary,
+                keywords,
+                ...(isEdit ? {} : { authorName }),
+            };
+
+            const res = await fetch(url, {
+                method,
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
+                },
+                body: JSON.stringify(payload),
+            });
+
+            if (!res.ok) throw new Error("저장 실패");
             setStatus("saved");
+
+            setTimeout(() => setStatus("idle"), 2000);
         } catch (e) {
             console.error(e);
             setStatus("idle");
         }
     };
 
-    /** 출간 요청 */
     const handlePublishRequest = async () => {
         setStatus("publishing");
         try {
-            // TODO: publishRequest(title, body, file)
-            await new Promise((r) => setTimeout(r, 2000));
+            const res = await fetch(`${API_BASE}/manuscripts/publication-request`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
+                },
+                body: JSON.stringify({
+                    manuscriptId: manuscriptId ?? null,
+                    authorId: user.userId,
+                }),
+            });
+
+            if (!res.ok) throw new Error("출간 요청 실패");
+
             setStatus("published");
+
+            alert("출간 요청이 완료되었습니다.");
+
+            // 원고 목록 페이지로 이동
+            navigate(`/manuscriptList`);
         } catch (e) {
             console.error(e);
+            alert("출간 요청 중 오류가 발생했습니다.");
             setStatus("idle");
         }
     };
@@ -58,59 +127,90 @@ export default function ManuscriptEditor() {
             initial={{ opacity: 0, y: 24 }}
             animate={{ opacity: 1, y: 0 }}
         >
+            <BackButton />
             <Card className="shadow-lg">
                 <CardHeader>
-                    <h1 className="text-2xl font-bold">원고 작성</h1>
+                    <h1 className="text-2xl font-bold">
+                        {isEdit ? "원고 수정" : "원고 작성"}
+                    </h1>
                 </CardHeader>
-                <CardContent className="flex flex-col gap-4">
-                    <Input
-                        placeholder="제목을 입력하세요"
-                        value={title}
-                        onChange={(e) => setTitle(e.target.value)}
-                    />
-                    <Textarea
-                        placeholder="내용을 입력하세요"
-                        rows={18}
-                        value={body}
-                        onChange={(e) => setBody(e.target.value)}
-                    />
 
-                    {/* 파일 업로드 */}
-                    <div className="flex items-center gap-4">
-                        <label className="flex cursor-pointer items-center gap-2 text-sm">
-                            <UploadCloud className="h-4 w-4" />
-                            <span>{file ? file.name : "첨부파일 업로드"}</span>
-                            <input
-                                type="file"
-                                accept=".doc,.docx,.pdf,.txt"
-                                onChange={handleFileChange}
-                                className="hidden"
-                            />
-                        </label>
+                <CardContent className="flex flex-col gap-4 text-sm">
+                    {/* 읽기 전용 정보 */}
+                    <p>👤 <strong>작성자:</strong> {authorName}</p>
+                    {isEdit && (
+                        <>
+                            <p>🏷️ <strong>상태:</strong> {getStatusLabel(statusText)}</p>
+                            <p>🕒 <strong>최근 수정:</strong> {lastModifiedAt?.split("T")[0]}</p>
+                        </>
+                    )}
+
+                    {/* 입력 폼 */}
+                    <div className="space-y-1">
+                        <label htmlFor="title">제목 :</label>
+                        <Input
+                            id="title"
+                            placeholder="제목을 입력하세요"
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="body">내용 :</label>
+                        <Textarea
+                            id="body"
+                            placeholder="내용을 입력하세요"
+                            rows={10}
+                            value={body}
+                            onChange={(e) => setBody(e.target.value)}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="summary">요약 :</label>
+                        <Input
+                            id="summary"
+                            placeholder="요약을 입력하세요 (선택)"
+                            value={summary}
+                            onChange={(e) => setSummary(e.target.value)}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="keywords">키워드 :</label>
+                        <Input
+                            id="keywords"
+                            placeholder="키워드를 입력하세요 (콤마로 구분, 선택)"
+                            value={keywords}
+                            onChange={(e) => setKeywords(e.target.value)}
+                        />
                     </div>
 
                     {/* 액션 버튼 */}
-                    <div className="flex justify-end gap-2">
-                        <Button
-                            variant="secondary"
-                            disabled={status === "saving" || status === "publishing"}
-                            onClick={handleSave}
-                        >
-                            {status === "saving" && (
-                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            )}
-                            저장
-                        </Button>
-                        <Button
-                            disabled={status === "publishing" || status === "saving"}
-                            onClick={handlePublishRequest}
-                        >
-                            {status === "publishing" && (
-                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            )}
-                            출간 요청
-                        </Button>
-                    </div>
+                    {statusText !== "PUBLICATION_REQUESTED" && (
+                        <div className="flex justify-end gap-2 mt-4">
+                            <Button
+                                disabled={status === "saving" || status === "publishing"}
+                                onClick={handleSave}
+                            >
+                                {status === "saving" && (
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                )}
+                                저장
+                            </Button>
+
+                            <Button
+                                disabled={status === "publishing" || status === "saving"}
+                                onClick={handlePublishRequest}
+                            >
+                                {status === "publishing" && (
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                )}
+                                출간 요청
+                            </Button>
+                        </div>)
+                    }
 
                     {/* 상태 메시지 */}
                     {status === "saved" && (

--- a/frontend/src/pages/ManuscriptList.js
+++ b/frontend/src/pages/ManuscriptList.js
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from "react";
+import { useAuth } from "../context/AuthContext";
+import { useNavigate } from "react-router-dom";
+import AppHeader from "../components/AppHeader";
+import {Button} from "../components/ui/button";
+import {getStatusLabel} from "../lib/statusUtils";
+
+export default function ManuscriptList() {
+    const { user } = useAuth();
+    const navigate = useNavigate();
+    const [manuscripts, setManuscripts] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const API_BASE = process.env.REACT_APP_API_URL;
+
+    useEffect(() => {
+        if (!user?.isAuthor) return;
+
+        const fetchManuscripts = async () => {
+            try {
+                const res = await fetch(`${API_BASE}/manuscripts/${user.userId}`, {
+                    headers: {
+                        Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
+                    },
+                });
+                if (!res.ok) throw new Error("원고 목록을 불러올 수 없습니다.");
+                const data = await res.json();
+                setManuscripts(data);
+            } catch (e) {
+                setError(e.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchManuscripts();
+    }, [API_BASE, user]);
+
+    if (!user?.isAuthor) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <p>작가만 접근할 수 있는 페이지입니다.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen flex flex-col">
+            <AppHeader isLoggedIn={!!user} isAuthor={user.isAuthor} />
+            <main className="container mx-auto px-6 py-10 max-w-4xl">
+                {loading && <p>원고 목록 불러오는 중...</p>}
+                {error && <p className="text-red-600">{error}</p>}
+
+                {!loading && !error && manuscripts.length === 0 && (
+                    <p className="text-gray-500 text-center">작성한 원고가 없습니다.</p>
+                )}
+
+                {!loading && !error && (
+                    <>
+                        <div className="flex items-center justify-between mb-4">
+                          <h2 className="text-2xl font-bold">✍️ 내 원고 목록</h2>
+                          <Button
+                              onClick={() =>
+                             navigate(`/manuscript/${user.userId}/new`)
+                            }
+                          >
+                            원고 등록
+                          </Button>
+                        </div>
+
+                        <table className="w-full table-auto border">
+                            <thead className="bg-gray-100">
+                            <tr>
+                                <th className="p-2 border">ID</th>
+                                <th className="p-2 border">제목</th>
+                                <th className="p-2 border">작성일</th>
+                                <th className="p-2 border">상태</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {manuscripts.map((m) => (
+                                <tr
+                                    key={m.id}
+                                    className="hover:bg-gray-100 cursor-pointer"
+                                    onClick={() => navigate(`/manuscript/${m.authorId}/${m.manuscriptId}`)}
+                                >
+                                    <td className="p-2 border text-center">{m.manuscriptId}</td>
+                                    <td className="p-2 border">{m.title}</td>
+                                    <td className="p-2 border text-center">
+                                        {m.lastModifiedAt?.split("T")[0]}
+                                    </td>
+                                    <td className="p-2 border text-center">{getStatusLabel(m.status)}</td>
+                                </tr>
+                            ))}
+                            </tbody>
+                        </table>
+                    </>
+                )}
+            </main>
+        </div>
+    );
+}

--- a/frontend/src/pages/MyPage.js
+++ b/frontend/src/pages/MyPage.js
@@ -1,9 +1,72 @@
-import React from "react";
+// src/pages/MyPage.jsx
+import React, { useEffect, useState } from "react";
 import AppHeader from "../components/AppHeader";
-import { useAuth } from "../context/AuthContext"; // ✅ 추가
+import { useAuth } from "../context/AuthContext";
 
 export default function MyPage() {
-    const { user } = useAuth(); // ✅ Context에서 로그인 사용자 정보 불러오기
+    const { user } = useAuth();
+    const [detail, setDetail] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const API_BASE = process.env.REACT_APP_API_URL;
+    const [subscribing, setSubscribing] = useState(false);
+
+    const handleSubscribe = async () => {
+        if (subscribing) return;           // 중복 클릭 방지
+        setSubscribing(true);
+
+        try {
+            const res = await fetch(`${API_BASE}/users/request-subscription`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
+                },
+                body: JSON.stringify({ userId: user.userId }), // ✅ 필요 시 수정
+            });
+
+            if (!res.ok) throw new Error("구독 신청 실패");
+
+            // 성공 시 최신 사용자 정보로 덮어쓰기 (옵션)
+            const updated = await res.json();      // { id, email, isAuthor, hasActiveSubscription, ... }
+            setDetail((prev) => ({ ...prev, subscribed: updated.hasActiveSubscription }));
+
+            alert("구독 신청이 완료되었습니다!");
+        } catch (e) {
+            alert(e.message || "구독 신청 중 오류가 발생했습니다.");
+        } finally {
+            setSubscribing(false);
+        }
+    };
+
+    useEffect(() => {
+        if (!user || !user.token) return;
+
+        const controller = new AbortController();
+
+        (async () => {
+            try {
+                const res = await fetch(`${API_BASE}/users/${user.userId}`, {
+                    method: "GET",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
+                    },
+                    signal: controller.signal,
+                });
+
+                if (!res.ok) throw new Error("사용자 정보를 불러올 수 없습니다.");
+                const data = await res.json();
+                setDetail(data);
+            } catch (e) {
+                if (e.name !== "AbortError") setError(e.message);
+            } finally {
+                setLoading(false);
+            }
+        })();
+
+        return () => controller.abort();
+    }, [API_BASE, user]);
 
     if (!user) {
         return (
@@ -13,54 +76,95 @@ export default function MyPage() {
         );
     }
 
-    // 임시 하드코딩 예시 대신 실제 user 정보
-    const userInfo = {
-        username: user.username || "익명 사용자",
-        email: user.email,
-        isKt: user.isKt,
-        subscribed: user.subscribed ?? false,
-        pointHistory: user.pointHistory || [],
-        viewedBooks: user.viewedBooks || [],
-    };
+    if (loading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <p>로딩 중…</p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <p>{error}</p>
+            </div>
+        );
+    }
+
+    if (!detail) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <p>잠시만 기다려주세요.</p>
+            </div>
+        );
+    }
+
+    const {
+        username,
+        email,
+        isKt,
+        pointHistory = [],
+        viewedBooks = [],
+    } = detail;
+
 
     return (
         <div className="min-h-screen flex flex-col">
-            <AppHeader /> {/* ✅ props 제거 */}
+            <AppHeader />
 
             <main className="container mx-auto px-6 py-8">
                 <h2 className="text-2xl font-bold mb-4">📌 마이페이지</h2>
 
-                <div className="bg-white border rounded-md p-6 mb-6">
-                    <p><strong>닉네임:</strong> {userInfo.username}</p>
-                    <p><strong>이메일:</strong> {userInfo.email}</p>
-                    <p><strong>KT 회원 여부:</strong> {userInfo.isKt ? "예" : "아니오"}</p>
-                    <p><strong>구독 상태:</strong> {userInfo.subscribed ? "구독 중" : "구독 안 함"}</p>
-                    {!userInfo.subscribed && (
-                        <button className="mt-2 px-4 py-2 bg-blue-600 text-white rounded-md">
-                            구독 신청
-                        </button>
-                    )}
-                </div>
+                <section className="bg-white border rounded-md p-6 mb-6">
+                    <div className="grid grid-cols-2 gap-x-8 gap-y-4">
+                        <p><strong>🧑 닉네임:</strong> {username || "익명 사용자"}</p>
+                        <div className="flex items-center justify-between">
+                            <p><strong>📦 구독 상태:</strong> {detail.hasActiveSubscription  ? "구독 중" : "구독 안 함"}</p>
 
-                <div className="mb-6">
+                            {!detail.hasActiveSubscription && (
+                                <button
+                                    onClick={handleSubscribe}
+                                    disabled={subscribing}
+                                    className={`ml-2 px-3 py-1 rounded-md text-sm
+                  ${subscribing ? "bg-gray-400 cursor-not-allowed" : "bg-blue-600 text-white"}`}
+                                >
+                                    {subscribing ? "요청 중..." : "구독 신청"}
+                                </button>
+                            )}
+                        </div>
+
+                        <p><strong>📧 이메일:</strong> {email}</p>
+                        {/*TODO: 작가 신청 버튼 연동 & 새로고침 필요*/}
+                        <div className="flex items-center justify-between">
+                            <p><strong>✍️ 작가 여부:</strong> {detail.isAuthor ? "작가입니다" : "아직 아닙니다"}</p>
+                            {!detail.isAuthor && (
+                                <button className="ml-2 px-3 py-1 bg-green-600 text-white text-sm rounded-md">
+                                    작가 신청
+                                </button>
+                            )}
+                        </div>
+
+                        <p><strong>📱 KT 회원 여부:</strong> {isKt ? "예" : "아니오"}</p>
+                        <p><strong>💰 포인트 잔액:</strong> 0</p>
+                    </div>
+                </section>
+
+
+
+
+                <section className="mb-6">
                     <h3 className="text-xl font-semibold mb-2">📘 열람한 책</h3>
-                    <ul className="list-disc list-inside">
-                        {userInfo.viewedBooks.map((book, i) => (
-                            <li key={i}>{book.title}</li>
-                        ))}
-                    </ul>
-                </div>
-
-                <div>
-                    <h3 className="text-xl font-semibold mb-2">💰 포인트 내역</h3>
-                    <ul className="list-disc list-inside">
-                        {userInfo.pointHistory.map((item, i) => (
-                            <li key={i}>
-                                {item.description}: {item.amount}P
-                            </li>
-                        ))}
-                    </ul>
-                </div>
+                    {viewedBooks.length === 0 ? (
+                        <p>열람한 책이 없습니다.</p>
+                    ) : (
+                        <ul className="list-disc list-inside">
+                            {viewedBooks.map((b, i) => (
+                                <li key={i}>{b.title}</li>
+                            ))}
+                        </ul>
+                    )}
+                </section>
             </main>
         </div>
     );

--- a/user/src/main/java/aivlecloudnative/application/UserService.java
+++ b/user/src/main/java/aivlecloudnative/application/UserService.java
@@ -170,6 +170,7 @@ public class UserService {
         return new UserInfoResponse(
                 user.getId(),
                 user.getEmail(),
+                user.getUserName(),
                 user.getIsKt(),
                 user.getIsAuthor(),
                 user.getHasActiveSubscription(),

--- a/user/src/main/java/aivlecloudnative/domain/UserInfoResponse.java
+++ b/user/src/main/java/aivlecloudnative/domain/UserInfoResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record UserInfoResponse(
         Long id,
         String email,
+        String username,
         boolean isKT,
         boolean isAuthor,
         boolean hasActiveSubscription,

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-server:
-  port: 8080
-
 spring:
   application:
     name: user

--- a/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
+++ b/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
@@ -243,6 +243,7 @@ class UserControllerTest {
         UserInfoResponse dto = new UserInfoResponse(
                 1L,
                 "user@example.com",
+                "test",
                 true,
                 true,
                 true,

--- a/writing/src/main/java/aivlecloudnative/infra/OutboxPublisher.java
+++ b/writing/src/main/java/aivlecloudnative/infra/OutboxPublisher.java
@@ -24,7 +24,6 @@ public class OutboxPublisher {
     @Scheduled(fixedDelay = 3000)
     @Transactional
     public void publishEvents() {
-        log.info("🟢 OutboxPublisher 스케줄러 실행됨");
         List<OutboxMessage> messages = outboxRepo.findByStatusOrderByCreatedAtAsc(OutboxMessage.PublishStatus.READY);
 
         for (OutboxMessage msg : messages) {
@@ -40,10 +39,8 @@ public class OutboxPublisher {
                 } else {
                     msg.setStatus(OutboxMessage.PublishStatus.FAILED);
                 }
-                log.info("✅ OutboxPublisher 스케줄러 실행됨. 메시지 개수: {}", messages.size());
             } catch (Exception e) {
                 msg.setStatus(OutboxMessage.PublishStatus.FAILED);
-                log.error("Outbox publish failed: {}", e.getMessage(), e);
             }
         }
     }

--- a/writing/src/main/resources/application.yml
+++ b/writing/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8086
 
 spring:
   application:


### PR DESCRIPTION
## ✨ 마이페이지 UI 구성 및 작가용 원고 관리 기능 구현

### 📌 주요 변경사항

#### ✅ 마이페이지 UI 및 API 연동
- 마이페이지 기본 UI 구성 완료
- 사용자 정보 조회 및 관련 API 연동 완료
- 잔여 포인트 데이터는 추후 연동 예정 (현재는 UI만 구성됨)

#### ✅ 작가용 원고 관리 기능 구현
- **원고 목록 조회**
  - 특정 작가 ID 기준으로 본인의 원고 리스트 조회
  - `GET /manuscripts/{authorId}` API 연동
- **원고 등록**
  - 신규 원고 작성 및 서버에 등록
  - `POST /manuscripts/registration` 요청
- **원고 수정**
  - 기존 원고 내용 수정 기능 구현
  - `PUT /manuscripts/${manuscriptId}/save` 요청
- **출간 요청**
  - 작성 완료된 원고에 대해 출간 요청 가능
  - `POST /manuscripts/publication-request` 등 출간 관련 API 호출

---

### 🧪 테스트 및 추가 고려 사항
- 마이페이지는 추후 잔여 포인트 연동 및 UX 개선 예정
