### PR TITLE
[feat] 작가 신청/승인, 도서 필터링, 포인트 연동 기능 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.2.1",
         "class-variance-authority": "^0.7.1",
         "framer-motion": "^12.20.1",
+        "jwt-decode": "^4.0.0",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -11087,6 +11088,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.2.1",
     "class-variance-authority": "^0.7.1",
     "framer-motion": "^12.20.1",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,7 +21,7 @@ function App() {
                 <Route path="/mypage" element={<MyPage />} />
 
                 <Route path="/manuscriptList" element={<ManuscriptList />} />
-                <Route path="/manuscript/:authorId/new" element={<ManuscriptEditor />} />
+
                 <Route path="/manuscript/:authorId/:manuscriptId" element={<ManuscriptEditor />} />
 
                 <Route path="/books" element={<AllBooksPage />} />

--- a/frontend/src/pages/AdminAuthorDetail.js
+++ b/frontend/src/pages/AdminAuthorDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import {useLocation, useParams} from "react-router-dom";
 import AppHeader from "../components/AppHeader";
 import { useAuth } from "../context/AuthContext";
 import { Button } from "../components/ui/button";
@@ -12,36 +12,35 @@ export default function AdminAuthorDetail() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [approving, setApproving] = useState(false);
+    const location = useLocation();
+    const passedAuthor = location.state;
 
     useEffect(() => {
-        // 더미 데이터
-        const dummyAuthor = {
-            id: Number(id),
-            authorEmail: "writer1@example.com",
-            authorName: "김작가",
-            bio: "문학을 사랑하는 작가입니다.",
-            representativeWork: "『봄날의 햇살』",
-            portfolio: "https://portfolio.example.com/kim",
-            isApproved: false,
-        };
-
-        setAuthor(dummyAuthor);
-        setLoading(false);
-    }, [id]);
+        if (passedAuthor) {
+            setAuthor(passedAuthor);
+            setLoading(false);
+        } else {
+            // TODO: Fallback - 실제 API 호출 등
+        }
+    }, [passedAuthor]);
 
     const handleApprove = async () => {
         setApproving(true);
         try {
-            // 실제 API 요청
-            // const res = await fetch(`${API_BASE}/admin/authors/${id}/approve`, {
-            //     method: "POST",
-            //     headers: {
-            //         Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
-            //     },
-            // });
-            // if (!res.ok) throw new Error("승인 실패");
+            const res = await fetch(`${API_BASE}/authors/judge`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
+                },
+                body: JSON.stringify({
+                    userId: author.userId,
+                    isApproved: true,
+                }),
+            });
 
-            // 더미 데이터일 경우 직접 업데이트
+            if (!res.ok) throw new Error("승인 실패");
+
             setAuthor((prev) => ({ ...prev, isApproved: true }));
         } catch (e) {
             alert("승인 중 오류 발생");
@@ -63,7 +62,7 @@ export default function AdminAuthorDetail() {
                     <div className="space-y-4">
                         <div><strong>ID:</strong> {author.id}</div>
                         <div><strong>이름:</strong> {author.authorName}</div>
-                        <div><strong>이메일:</strong> {author.authorEmail}</div>
+                        <div><strong>이메일:</strong> {author.email}</div>
                         <div><strong>대표 작품:</strong> {author.representativeWork || "없음"}</div>
                         <div><strong>포트폴리오:</strong> {author.portfolio || "없음"}</div>
                         <div><strong>소개:</strong> {author.bio || "없음"}</div>

--- a/frontend/src/pages/AllBooksPage.js
+++ b/frontend/src/pages/AllBooksPage.js
@@ -1,13 +1,11 @@
-// src/pages/AllBooksPage.jsx
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Button } from "../components/ui/button";
 import AppHeader from "../components/AppHeader";
 import { useAuth } from "../context/AuthContext";
 
 export default function AllBooksPage() {
     const navigate = useNavigate();
-    const { user, isLoggedIn, isAuthor } = useAuth();
+    const { user, isLoggedIn } = useAuth();
     const userId = user?.userId ?? 0;
 
     const API_BASE = process.env.REACT_APP_API_URL;

--- a/frontend/src/pages/AllBooksPage.js
+++ b/frontend/src/pages/AllBooksPage.js
@@ -1,29 +1,39 @@
+// src/pages/AllBooksPage.jsx
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "../components/ui/button";
 import AppHeader from "../components/AppHeader";
+import { useAuth } from "../context/AuthContext";
 
-export default function AllBooksPage({ isLoggedIn = false, isAuthor = false }) {
+export default function AllBooksPage() {
     const navigate = useNavigate();
-
-    const [books, setBooks] = useState([]);
-    const [searchQuery, setSearchQuery] = useState("");
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState(null);
+    const { user, isLoggedIn, isAuthor } = useAuth();
+    const userId = user?.userId ?? 0;
 
     const API_BASE = process.env.REACT_APP_API_URL;
 
-    // 📡 fetch 사용
+    /* ───────── state ───────── */
+    const [books, setBooks] = useState([]);
+    const [viewedBookIds, setViewedBookIds] = useState([]);
+    const [searchQuery, setSearchQuery] = useState("");
+    const [showReadOnly, setShowReadOnly] = useState(false);   // ← 하나만 사용
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    /* ───────── effect ───────── */
+    useEffect(() => {
+        fetchBooks();
+        if (userId) fetchViewedBooks(userId);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [userId]);
+
     const fetchBooks = async () => {
         setLoading(true);
         setError(null);
         try {
-            const response = await fetch(`${API_BASE}/books?page=0&size=200`);
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-
-            const data = await response.json();
+            const res = await fetch(`${API_BASE}/books?page=0&size=200`);
+            if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+            const data = await res.json();
             setBooks(data.content);
         } catch (err) {
             setError(err.message || "네트워크 오류");
@@ -32,47 +42,76 @@ export default function AllBooksPage({ isLoggedIn = false, isAuthor = false }) {
         }
     };
 
-    useEffect(() => {
-        fetchBooks();
-    }, []);
+    const fetchViewedBooks = async (uid) => {
+        try {
+            const res = await fetch(`${API_BASE}/bookViews/users/${uid}`);
+            if (res.ok) {
+                const data = await res.json();          // [{ bookId, ... }]
+                setViewedBookIds(data.map(v => v.bookId));
+            }
+        } catch (err) {
+            console.error("열람 기록 조회 실패:", err);
+        }
+    };
 
-    const filteredBooks = books.filter((b) =>
-        b.title.toLowerCase().includes(searchQuery.toLowerCase())
-    );
+    /* ───────── filter ───────── */
+    const filteredBooks = books.filter(b => {
+        const matches = b.title.toLowerCase().includes(searchQuery.toLowerCase());
+        if (!matches) return false;
+        if (!showReadOnly) return true;             // 전체 보기
+        return viewedBookIds.includes(b.id);        // 읽은 책만
+    });
 
+    /* ───────── UI ───────── */
     return (
         <div className="min-h-screen flex flex-col">
-            <AppHeader isLoggedIn={isLoggedIn} isAuthor={isAuthor} />
+            <AppHeader />
 
             <main className="container mx-auto px-6 py-8">
                 <h2 className="text-2xl font-bold mb-4">📚 전체 책 목록</h2>
 
+                {/* 검색 · 필터 · 원고등록 */}
                 <div className="flex justify-between items-center mb-6">
-                    <input
-                        type="text"
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        placeholder="책 제목 검색"
-                        className="border px-4 py-2 rounded-md w-full max-w-xs"
-                    />
-
-                    {isAuthor && (
-                        <Button className="ml-4" onClick={() => navigate("/manuscript")}>
-                            원고 등록
-                        </Button>
-                    )}
+                    <div className="flex items-center gap-2">
+                        <input
+                            value={searchQuery}
+                            onChange={e => setSearchQuery(e.target.value)}
+                            placeholder="책 제목 검색"
+                            className="border px-4 py-2 rounded-md w-60"
+                        />
+                        {isLoggedIn && (
+                            <button
+                                onClick={() => setShowReadOnly(prev => !prev)}
+                                className={`px-3 py-2 rounded-md text-sm font-medium border transition
+                  ${showReadOnly
+                                    ? "bg-blue-600 text-white hover:bg-blue-700 border-blue-600"
+                                    : "bg-white text-gray-700 hover:bg-gray-100 border-gray-300"}
+                `}
+                            >
+                                {showReadOnly ? "📘 읽은 책만 보기" : "📚 전체 보기"}
+                            </button>
+                        )}
+                    </div>
                 </div>
 
+                {/* 목록 or 메시지 */}
                 {loading && <p>로딩 중...</p>}
                 {error && <p className="text-red-500">{error}</p>}
-                {!loading && !error && filteredBooks.length === 0 && <p>도서가 없습니다.</p>}
+
+                {!loading && !error && filteredBooks.length === 0 && (
+                    <p className="text-gray-500 text-center">
+                        {showReadOnly
+                            ? "읽은 책이 없습니다."
+                            : "조건에 맞는 도서가 없습니다."}
+                    </p>
+                )}
 
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-                    {filteredBooks.map((book) => (
+                    {filteredBooks.map(book => (
                         <div
                             key={book.id}
-                            className="bg-white border shadow rounded-md p-4 hover:shadow-md cursor-pointer"
                             onClick={() => navigate(`/book/${book.id}`)}
+                            className="bg-white border shadow rounded-md p-4 hover:shadow-md cursor-pointer"
                         >
                             <div
                                 className="w-full h-40 bg-gray-200 mb-2"
@@ -82,7 +121,9 @@ export default function AllBooksPage({ isLoggedIn = false, isAuthor = false }) {
                                     backgroundPosition: "center",
                                 }}
                             />
-                            <div className="text-sm font-semibold text-center">{book.title}</div>
+                            <div className="text-sm font-semibold text-center">
+                                {book.title}
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/AuthorApplyModal.js
+++ b/frontend/src/pages/AuthorApplyModal.js
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+
+export default function AuthorApplyModal({ onClose, onSubmit, isSubmitting }) {
+    const [bio, setBio] = useState("");
+    const [portfolio, setPortfolio] = useState("");
+    const [representativeWork, setRepresentativeWork] = useState("");
+
+    const handleSubmit = () => {
+        if (!bio || !portfolio || !representativeWork) {
+            alert("모든 항목을 입력해주세요.");
+            return;
+        }
+        onSubmit({ bio, portfolio, representativeWork });
+    };
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
+            <div className="bg-white p-6 rounded-md w-[90%] max-w-md shadow">
+                <h2 className="text-xl font-semibold mb-4">✍️ 작가 신청</h2>
+
+                <label className="block mb-2 text-sm font-medium">
+                    자기소개 (bio)
+                    <textarea
+                        className="mt-1 w-full border px-3 py-2 rounded"
+                        rows={3}
+                        value={bio}
+                        onChange={(e) => setBio(e.target.value)}
+                    />
+                </label>
+
+                <label className="block mb-2 text-sm font-medium">
+                    대표 작품명
+                    <input
+                        type="text"
+                        className="mt-1 w-full border px-3 py-2 rounded"
+                        value={representativeWork}
+                        onChange={(e) => setRepresentativeWork(e.target.value)}
+                    />
+                </label>
+
+                <label className="block mb-4 text-sm font-medium">
+                    포트폴리오 링크
+                    <input
+                        type="text"
+                        className="mt-1 w-full border px-3 py-2 rounded"
+                        value={portfolio}
+                        onChange={(e) => setPortfolio(e.target.value)}
+                    />
+                </label>
+
+                <div className="flex justify-end gap-2">
+                    <button
+                        onClick={onClose}
+                        className="px-4 py-2 border rounded text-sm"
+                    >
+                        취소
+                    </button>
+                    <button
+                        onClick={handleSubmit}
+                        disabled={isSubmitting}
+                        className={`px-4 py-2 text-white rounded text-sm ${isSubmitting ? "bg-gray-400" : "bg-green-600 hover:bg-green-700"}`}
+                    >
+                        {isSubmitting ? "제출 중..." : "신청"}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/BookDetail.js
+++ b/frontend/src/pages/BookDetail.js
@@ -1,96 +1,104 @@
+// src/pages/BookDetail.jsx
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import AppHeader from "../components/AppHeader";
-import {useAuth} from "../context/AuthContext";
+import { useAuth } from "../context/AuthContext";
 
 export default function BookDetail() {
-    const { id } = useParams();
-    const { user } = useAuth();
+    const { id } = useParams();                     // 📕 현재 조회 중인 도서 ID (path param)
+    const { user }   = useAuth();                   // 🔑 로그인 정보
     const isLoggedIn = !!user;
-    const userId = user?.userId || 0;
-    const [book, setBook] = useState(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
-    const [requestStatus, setRequestStatus] = useState(null);
-    const [hasViewed, setHasViewed] = useState(false);
-    const [isRequesting, setIsRequesting] = useState(false);
+    const userId     = user?.userId ?? 0;
 
     const API_BASE = process.env.REACT_APP_API_URL;
 
+    /* ──────────────── state ──────────────── */
+    const [book,        setBook]        = useState(null);
+    const [loading,     setLoading]     = useState(true);
+    const [error,       setError]       = useState(null);
+    const [hasAccess,   setHasAccess]   = useState(false);
+    const [isRequesting,setIsRequesting]= useState(false);
+    const [requestMsg,  setRequestMsg]  = useState(null);
+
+    /* ──────────────── effect: 도서 + 열람권한 ──────────────── */
     useEffect(() => {
-        const fetchBookDetail = async () => {
+        const controller = new AbortController();
+
+        const fetchBookAndAccess = async () => {
             try {
-                const res = await fetch(`${API_BASE}/books/${id}`);
-                if (!res.ok) throw new Error("도서 정보를 불러오는 데 실패했습니다.");
-                const data = await res.json();
-                setBook(data);
+                /* 1) 도서 상세 */
+                const bookRes = await fetch(`${API_BASE}/books/${id}`, { signal: controller.signal });
+                if (!bookRes.ok) throw new Error("도서 정보를 불러오는 데 실패했습니다.");
+                const bookData = await bookRes.json();
+                setBook(bookData);
+
+                /* 2) 열람 기록 (로그인한 사용자인 경우에만) */
+                if (userId) {
+                    const viewRes = await fetch(`${API_BASE}/bookViews/users/${userId}`, { signal: controller.signal });
+                    if (viewRes.ok) {
+                        const views = await viewRes.json();            // [{bookId, …}, …]
+                        const viewed = views.some(v => v.bookId === Number(id));
+                        setHasAccess(viewed);
+                    }
+                }
             } catch (err) {
-                setError(err.message || "알 수 없는 오류");
+                if (err.name !== "AbortError") {
+                    setError(err.message || "알 수 없는 오류가 발생했습니다.");
+                }
             } finally {
                 setLoading(false);
             }
         };
 
-        const fetchViewRecord = async () => {
-            if (!userId) return;
-            const res = await fetch(`${API_BASE}/bookViews/users/${userId}`);
-            if (res.ok) {
-                const views = await res.json();
-                const hasViewed = views.some(view => view.bookId === parseInt(id));
-                setHasViewed(hasViewed);
-            }
-        };
-
-        fetchBookDetail();
-        fetchViewRecord();
+        fetchBookAndAccess();
+        return () => controller.abort();
     }, [id, API_BASE, userId]);
 
     const handleAccessRequest = async () => {
-        try {
-            setRequestStatus(null);
-            setIsRequesting(true);
+        if (!isLoggedIn || isRequesting) return;
 
+        setIsRequesting(true);
+        setRequestMsg(null);
+
+        try {
             const res = await fetch(`${API_BASE}/users/request-content-access`, {
-                method: "POST",
+                method : "POST",
                 headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${user.token}`,
                 },
-                body: JSON.stringify({
-                    userId,
-                    bookId: parseInt(id),
-                }),
+                body: JSON.stringify({ userId, bookId: Number(id) }),
             });
 
-            if (!res.ok) throw new Error("열람 신청에 실패했습니다.");
-            setRequestStatus("✅ 열람 신청이 완료되었습니다.");
+            if (!res.ok) throw new Error();
 
-            setTimeout(() => {
-                window.location.reload();
-            }, 3000);
-        } catch (err) {
-            setRequestStatus("❌ 열람 신청 중 오류가 발생했습니다.");
+            setRequestMsg("✅ 열람 신청이 완료되었습니다!");
+
+            setTimeout(() => window.location.reload(), 3000);
+        } catch {
+            setRequestMsg("❌ 열람 신청 중 오류가 발생했습니다.");
             setIsRequesting(false);
         }
     };
 
-
-
-    if (loading) return <div className="p-8">로딩 중...</div>;
-    if (error) return <div className="p-8 text-red-500">{error}</div>;
-    if (!book) return <div className="p-8">도서를 찾을 수 없습니다.</div>;
+    if (loading)  return <div className="p-8">로딩 중...</div>;
+    if (error)    return <div className="p-8 text-red-500">{error}</div>;
+    if (!book)    return <div className="p-8">도서를 찾을 수 없습니다.</div>;
 
     return (
         <div className="min-h-screen flex flex-col">
             <AppHeader />
+
             <main className="container mx-auto px-6 py-10 max-w-4xl">
                 <div className="flex flex-col md:flex-row gap-8">
+                    {/* ───── 표지 ───── */}
                     <img
                         src={book.coverImageUrl}
                         alt="표지 이미지"
                         className="w-48 h-64 object-cover border rounded shadow"
                     />
 
+                    {/* ───── 메타 정보 & 콘텐츠 ───── */}
                     <div className="flex flex-col gap-2">
                         <h1 className="text-2xl font-bold">{book.title}</h1>
                         <p className="text-gray-700">저자: {book.authorName}</p>
@@ -99,31 +107,47 @@ export default function BookDetail() {
                         <p className="text-gray-900 font-semibold mt-2">
                             가격: {book.price?.toLocaleString()}원
                         </p>
-                        <p className="mt-4 whitespace-pre-wrap">요약: {book.summary}</p>
-                        <a
-                            href={book.ebookUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="mt-6 inline-block text-blue-600 underline"
-                        >
-                            전자책 보기
-                        </a>
 
-                        {/* 열람 신청 */}
-                        {/* 열람 신청 */}
-                        {isLoggedIn && !hasViewed && (
-                            <button
-                                onClick={handleAccessRequest}
-                                disabled={isRequesting}
-                                className={`mt-6 px-4 py-2 rounded text-white transition ${
-                                    isRequesting ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700'
-                                }`}
-                            >
-                                {isRequesting ? '신청 중...' : '열람 신청'}
-                            </button>
+                        {/* ───── 열람 권한 有 ───── */}
+                        {hasAccess ? (
+                            <>
+                                <a
+                                    href={book.ebookUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="mt-6 inline-block text-blue-600 underline"
+                                >
+                                    전자책 보기
+                                </a>
+                            </>
+                        ) : (
+                            /* ───── 열람 권한 無 ───── */
+                            <>
+
+                                <p className="mt-4 whitespace-pre-wrap">요약: {book.summary}</p>
+                                <p className="mt-4 text-sm text-gray-500">
+                                    ※ 열람 권한이 있는 사용자만 내용을 볼 수 있습니다.
+                                </p>
+
+                                {isLoggedIn && (
+                                    <button
+                                        onClick={handleAccessRequest}
+                                        disabled={isRequesting}
+                                        className={`mt-4 px-4 py-2 rounded text-white transition ${
+                                            isRequesting
+                                                ? "bg-gray-400 cursor-not-allowed"
+                                                : "bg-blue-600 hover:bg-blue-700"
+                                        }`}
+                                    >
+                                        {isRequesting ? "신청 중..." : "열람 신청"}
+                                    </button>
+                                )}
+
+                                {requestMsg && (
+                                    <p className="mt-2 text-sm">{requestMsg}</p>
+                                )}
+                            </>
                         )}
-                        {requestStatus && <p className="mt-2 text-sm">{requestStatus}</p>}
-
                     </div>
                 </div>
             </main>

--- a/frontend/src/pages/ManuscriptEditor.js
+++ b/frontend/src/pages/ManuscriptEditor.js
@@ -60,7 +60,6 @@ export default function ManuscriptEditor() {
             const url = isEdit
                 ? `${API_BASE}/manuscripts/${manuscriptId}/save`
                 : `${API_BASE}/manuscripts/registration`;
-
             const method = isEdit ? "PUT" : "POST";
 
             const payload = {
@@ -82,14 +81,19 @@ export default function ManuscriptEditor() {
             });
 
             if (!res.ok) throw new Error("저장 실패");
-            setStatus("saved");
 
-            setTimeout(() => setStatus("idle"), 2000);
+            // 저장 성공 시 3초 후 리스트로 새로고침 이동
+            setStatus("saved");
+            window.location.href = "/manuscriptList";
+            setTimeout(() => {
+            }, 3000); // 3초 후 이동
+
         } catch (e) {
             console.error(e);
             setStatus("idle");
         }
     };
+
 
     const handlePublishRequest = async () => {
         setStatus("publishing");
@@ -194,23 +198,23 @@ export default function ManuscriptEditor() {
                                 disabled={status === "saving" || status === "publishing"}
                                 onClick={handleSave}
                             >
-                                {status === "saving" && (
-                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                )}
+                                {status === "saving" && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                                 저장
                             </Button>
 
-                            <Button
-                                disabled={status === "publishing" || status === "saving"}
-                                onClick={handlePublishRequest}
-                            >
-                                {status === "publishing" && (
-                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                )}
-                                출간 요청
-                            </Button>
-                        </div>)
-                    }
+                            {isEdit && (
+                                <Button
+                                    disabled={status === "publishing" || status === "saving"}
+                                    onClick={handlePublishRequest}
+                                >
+                                    {status === "publishing" && (
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    )}
+                                    출간 요청
+                                </Button>
+                            )}
+                        </div>
+                    )}
 
                     {/* 상태 메시지 */}
                     {status === "saved" && (

--- a/frontend/src/pages/ManuscriptList.js
+++ b/frontend/src/pages/ManuscriptList.js
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom";
 import AppHeader from "../components/AppHeader";
-import {Button} from "../components/ui/button";
-import {getStatusLabel} from "../lib/statusUtils";
+import { Button } from "../components/ui/button";
+import { getStatusLabel } from "../lib/statusUtils";
 
 export default function ManuscriptList() {
     const { user } = useAuth();
@@ -47,26 +47,21 @@ export default function ManuscriptList() {
     return (
         <div className="min-h-screen flex flex-col">
             <AppHeader isLoggedIn={!!user} isAuthor={user.isAuthor} />
+
             <main className="container mx-auto px-6 py-10 max-w-4xl">
+
+                {/* 상단 새 원고 작성 버튼 */}
+                <div className="flex justify-end mb-6">
+                    <Button onClick={() => navigate(`/manuscript/${user.userId}/new`)}>
+                        ✍️ 새 원고 작성하기
+                    </Button>
+                </div>
+
                 {loading && <p>원고 목록 불러오는 중...</p>}
-                {error && <p className="text-red-600">{error}</p>}
 
-                {!loading && !error && manuscripts.length === 0 && (
-                    <p className="text-gray-500 text-center">작성한 원고가 없습니다.</p>
-                )}
-
-                {!loading && !error && (
+                {!loading && (
                     <>
-                        <div className="flex items-center justify-between mb-4">
-                          <h2 className="text-2xl font-bold">✍️ 내 원고 목록</h2>
-                          <Button
-                              onClick={() =>
-                             navigate(`/manuscript/${user.userId}/new`)
-                            }
-                          >
-                            원고 등록
-                          </Button>
-                        </div>
+                        <h2 className="text-2xl font-bold mb-4">📄 내 원고 목록</h2>
 
                         <table className="w-full table-auto border">
                             <thead className="bg-gray-100">
@@ -78,20 +73,26 @@ export default function ManuscriptList() {
                             </tr>
                             </thead>
                             <tbody>
-                            {manuscripts.map((m) => (
-                                <tr
-                                    key={m.id}
-                                    className="hover:bg-gray-100 cursor-pointer"
-                                    onClick={() => navigate(`/manuscript/${m.authorId}/${m.manuscriptId}`)}
-                                >
-                                    <td className="p-2 border text-center">{m.manuscriptId}</td>
-                                    <td className="p-2 border">{m.title}</td>
-                                    <td className="p-2 border text-center">
-                                        {m.lastModifiedAt?.split("T")[0]}
+                            {!error && manuscripts.length === 0 ? (
+                                <tr>
+                                    <td colSpan="4" className="p-4 text-center text-gray-500">
+                                        작성한 원고가 없습니다.
                                     </td>
-                                    <td className="p-2 border text-center">{getStatusLabel(m.status)}</td>
                                 </tr>
-                            ))}
+                            ) : (
+                                manuscripts.map((m) => (
+                                    <tr
+                                        key={m.manuscriptId}
+                                        className="hover:bg-gray-100 cursor-pointer"
+                                        onClick={() => navigate(`/manuscript/${m.authorId}/${m.manuscriptId}`)}
+                                    >
+                                        <td className="p-2 border text-center">{m.manuscriptId}</td>
+                                        <td className="p-2 border">{m.title}</td>
+                                        <td className="p-2 border text-center">{m.lastModifiedAt?.split("T")[0]}</td>
+                                        <td className="p-2 border text-center">{getStatusLabel(m.status)}</td>
+                                    </tr>
+                                ))
+                            )}
                             </tbody>
                         </table>
                     </>

--- a/frontend/src/pages/MyPage.js
+++ b/frontend/src/pages/MyPage.js
@@ -99,6 +99,7 @@ export default function MyPage() {
                     }),
                 ]);
 
+                // ✅ 유저 정보
                 if (!userRes.ok) throw new Error("사용자 정보를 불러올 수 없습니다.");
                 const userData = await userRes.json();
                 setDetail(userData);
@@ -216,22 +217,6 @@ export default function MyPage() {
                         <p><strong>📱 KT 회원 여부:</strong> {isKt ? "예" : "아니오"}</p>
                         <p><strong>💰 포인트 잔액:</strong> 0</p>
                     </div>
-                </section>
-
-
-
-
-                <section className="mb-6">
-                    <h3 className="text-xl font-semibold mb-2">📘 열람한 책</h3>
-                    {viewedBooks.length === 0 ? (
-                        <p>열람한 책이 없습니다.</p>
-                    ) : (
-                        <ul className="list-disc list-inside">
-                            {viewedBooks.map((b, i) => (
-                                <li key={i}>{b.title}</li>
-                            ))}
-                        </ul>
-                    )}
                 </section>
             </main>
         </div>

--- a/frontend/src/pages/MyPage.js
+++ b/frontend/src/pages/MyPage.js
@@ -1,116 +1,122 @@
-// src/pages/MyPage.jsx
 import React, { useEffect, useState } from "react";
-import AppHeader from "../components/AppHeader";
-import { useAuth } from "../context/AuthContext";
-import AuthorApplyModal from "../pages/AuthorApplyModal";
+import AppHeader                from "../components/AppHeader";
+import { useAuth }              from "../context/AuthContext";
+import AuthorApplyModal         from "../pages/AuthorApplyModal";
+import { Button }               from "../components/ui/button";
+
+/* ───────────────────────────────────── */
 
 export default function MyPage() {
-    const { user } = useAuth();
-    const [detail, setDetail] = useState(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
-    const API_BASE = process.env.REACT_APP_API_URL;
-    const [subscribing, setSubscribing] = useState(false);
-    const [showAuthorModal, setShowAuthorModal] = useState(false);
-    const [applyingAuthor, setApplyingAuthor] = useState(false);
-    const [authorStatus, setAuthorStatus] = useState(null); // 작가 신청 상태
+    const { user }   = useAuth();
+    const API_BASE   = process.env.REACT_APP_API_URL;
 
+    /* -------- state -------- */
+    const [detail,        setDetail]        = useState(null);
+    const [authorStatus,  setAuthorStatus]  = useState(null);          // APPLIED | ACCEPTED | REJECTED | null
+    const [pointBalance,  setPointBalance]  = useState(0);
+
+    const [loading,       setLoading]       = useState(true);
+    const [error,         setError]         = useState(null);
+
+    const [subscribing,   setSubscribing]   = useState(false);         // 🔑 버튼 disabled 용
+    const [showModal,     setShowModal]     = useState(false);
+    const [applying,      setApplying]      = useState(false);
+
+    /* -------- 구독 신청 -------- */
     const handleSubscribe = async () => {
         if (subscribing) return;
         setSubscribing(true);
 
         try {
             const res = await fetch(`${API_BASE}/users/request-subscription`, {
-                method: "POST",
+                method : "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
+                    Authorization : `${user.tokenType ?? "Bearer"} ${user.token}`
                 },
-                body: JSON.stringify({ userId: user.userId }), // ✅ 필요 시 수정
+                body: JSON.stringify({ userId: user.userId })
             });
 
-            if (!res.ok) throw new Error("구독 신청 실패");
-
-            const updated = await res.json();
-            setDetail((prev) => ({ ...prev, subscribed: updated.hasActiveSubscription }));
-
-            alert("구독 신청이 완료되었습니다!");
-
-            window.location.reload();
+            if (!res.ok) throw new Error("구독 신청 실패 😢");
+            alert("✅ 구독 신청이 완료되었습니다!");
+            window.location.reload();                 // 새로고침으로 상태 반영
         } catch (e) {
-            alert(e.message || "구독 신청 중 오류가 발생했습니다.");
+            alert(e.message);
         } finally {
             setSubscribing(false);
         }
     };
 
-    const handleSubmitAuthorApply = async ({ bio, portfolio, representativeWork }) => {
-        setApplyingAuthor(true);
+    /* -------- 작가 신청 -------- */
+    const handleSubmitAuthorApply = async (payload) => {
+        setApplying(true);
         try {
             const res = await fetch(`${API_BASE}/authors/apply`, {
-                method: "POST",
+                method : "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    Authorization: `Bearer ${user.token}`,
+                    Authorization : `Bearer ${user.token}`
                 },
                 body: JSON.stringify({
-                    authorEmail: user.email,
-                    authorName: user.username,
-                    bio,
-                    representativeWork,
-                    portfolio,
-                }),
+                    authorEmail        : user.email,
+                    authorName         : user.username,
+                    ...payload
+                })
             });
-
             if (!res.ok) throw new Error("작가 신청 실패");
 
-            alert("✅ 작가 신청이 완료되었습니다!");
+            alert("✍️ 작가 신청이 접수되었습니다!");
             window.location.reload();
         } catch (e) {
-            alert(e.message || "❌ 신청 중 오류 발생");
+            alert(e.message);
         } finally {
-            setApplyingAuthor(false);
+            setApplying(false);
         }
     };
 
-
+    /* -------- 세 가지 정보 한 꺼번에 조회 -------- */
     useEffect(() => {
-        if (!user || !user.token) return;
+        if (!user?.token) return;
 
         const controller = new AbortController();
 
         (async () => {
             try {
-                const [userRes, authorRes] = await Promise.all([
+                const [uRes, aRes, pRes] = await Promise.all([
                     fetch(`${API_BASE}/users/${user.userId}`, {
-                        method: "GET",
                         headers: {
                             "Content-Type": "application/json",
-                            Authorization: `${user.tokenType ?? "Bearer"} ${user.token}`,
+                            Authorization : `${user.tokenType ?? "Bearer"} ${user.token}`
                         },
-                        signal: controller.signal,
+                        signal: controller.signal
                     }),
                     fetch(`${API_BASE}/authors/my-data`, {
-                        method: "GET",
-                        headers: {
-                            Authorization: `Bearer ${user.token}`,
-                        },
-                        signal: controller.signal,
+                        headers: { Authorization: `Bearer ${user.token}` },
+                        signal : controller.signal
                     }),
+                    fetch(`${API_BASE}/points/${user.userId}`, {
+                        headers: { Authorization: `Bearer ${user.token}` },
+                        signal : controller.signal
+                    })
                 ]);
 
-                // ✅ 유저 정보
-                if (!userRes.ok) throw new Error("사용자 정보를 불러올 수 없습니다.");
-                const userData = await userRes.json();
-                setDetail(userData);
+                /* 1) 사용자 */
+                if (!uRes.ok) throw new Error("사용자 정보를 불러올 수 없습니다.");
+                setDetail(await uRes.json());
 
-                if (authorRes.ok) {
-                    const authorData = await authorRes.json();
-                    setAuthorStatus(authorData.status); // APPLIED, ACCEPTED, REJECTED
+                /* 2) 작가 */
+                if (aRes.ok) {
+                    const { status } = await aRes.json();
+                    setAuthorStatus(status);
                 } else {
-                    setAuthorStatus(null); // 신청 이력 없음
+                    setAuthorStatus(null);
                 }
 
+                /* 3) 포인트 */
+                if (pRes.ok) {
+                    const { currentPoints } = await pRes.json();
+                    setPointBalance(currentPoints);
+                }
             } catch (e) {
                 if (e.name !== "AbortError") setError(e.message);
             } finally {
@@ -121,48 +127,13 @@ export default function MyPage() {
         return () => controller.abort();
     }, [API_BASE, user]);
 
+    /* --------  UI 스켈레톤 -------- */
+    if (!user)          return <FullMsg>로그인이 필요합니다.</FullMsg>;
+    if (loading)        return <FullMsg>로딩 중…</FullMsg>;
+    if (error)          return <FullMsg>{error}</FullMsg>;
+    if (!detail)        return <FullMsg>잠시만 기다려주세요.</FullMsg>;
 
-
-    if (!user) {
-        return (
-            <div className="min-h-screen flex items-center justify-center">
-                <p>로그인이 필요합니다.</p>
-            </div>
-        );
-    }
-
-    if (loading) {
-        return (
-            <div className="min-h-screen flex items-center justify-center">
-                <p>로딩 중…</p>
-            </div>
-        );
-    }
-
-    if (error) {
-        return (
-            <div className="min-h-screen flex items-center justify-center">
-                <p>{error}</p>
-            </div>
-        );
-    }
-
-    if (!detail) {
-        return (
-            <div className="min-h-screen flex items-center justify-center">
-                <p>잠시만 기다려주세요.</p>
-            </div>
-        );
-    }
-
-    const {
-        username,
-        email,
-        isKt,
-        pointHistory = [],
-        viewedBooks = [],
-    } = detail;
-
+    const { username, email, isKT, hasActiveSubscription } = detail;
 
     return (
         <div className="min-h-screen flex flex-col">
@@ -173,52 +144,59 @@ export default function MyPage() {
 
                 <section className="bg-white border rounded-md p-6 mb-6">
                     <div className="grid grid-cols-2 gap-x-8 gap-y-4">
+                        {/* 닉네임 */}
                         <p><strong>🧑 닉네임:</strong> {username || "익명 사용자"}</p>
-                        <div className="flex items-center justify-between">
-                            <p><strong>📦 구독 상태:</strong> {detail.hasActiveSubscription  ? "구독 중" : "구독 안 함"}</p>
 
-                            {!detail.hasActiveSubscription && (
-                                <button
-                                    onClick={handleSubscribe}
+                        {/* 구독 상태 + 버튼 */}
+                        <div className="flex items-center justify-between">
+                            <p><strong>📦 구독 상태:</strong> {hasActiveSubscription ? "구독 중" : "구독 안 함"}</p>
+                            {!hasActiveSubscription && (
+                                <Button
+                                    size="sm"
                                     disabled={subscribing}
-                                    className={`ml-2 px-3 py-1 rounded-md text-sm
-                  ${subscribing ? "bg-gray-400 cursor-not-allowed" : "bg-blue-600 text-white"}`}
+                                    onClick={handleSubscribe}
                                 >
-                                    {subscribing ? "요청 중..." : "구독 신청"}
-                                </button>
+                                    {subscribing ? "요청 중…" : "구독 신청"}
+                                </Button>
                             )}
                         </div>
 
+                        {/* 이메일 */}
                         <p><strong>📧 이메일:</strong> {email}</p>
-                        {/*TODO: 작가 신청 버튼 연동 & 새로고침 필요*/}
+
+                        {/* 작가 상태 + 버튼 */}
                         <div className="flex items-center justify-between">
                             <p><strong>✍️ 작가 여부:</strong> {authorStatus === "ACCEPTED" ? "작가입니다" : "아직 아닙니다"}</p>
 
                             {(authorStatus === null || authorStatus === "REJECTED") && (
                                 <>
-                                    <button
-                                        className="ml-2 px-3 py-1 bg-green-600 text-white text-sm rounded-md"
-                                        onClick={() => setShowAuthorModal(true)}
-                                    >
-                                        작가 신청
-                                    </button>
-
-                                    {showAuthorModal && (
+                                    <Button size="sm" onClick={() => setShowModal(true)}>작가 신청</Button>
+                                    {showModal && (
                                         <AuthorApplyModal
-                                            onClose={() => setShowAuthorModal(false)}
+                                            onClose={() => setShowModal(false)}
                                             onSubmit={handleSubmitAuthorApply}
-                                            isSubmitting={applyingAuthor}
+                                            isSubmitting={applying}
                                         />
                                     )}
                                 </>
                             )}
                         </div>
 
-                        <p><strong>📱 KT 회원 여부:</strong> {isKt ? "예" : "아니오"}</p>
-                        <p><strong>💰 포인트 잔액:</strong> 0</p>
+                        {/* KT · 포인트 */}
+                        <p><strong>📱 KT 회원 여부:</strong> {isKT ? "예" : "아니오"}</p>
+                        <p><strong>💰 포인트 잔액:</strong> {pointBalance.toLocaleString()} P</p>
                     </div>
                 </section>
             </main>
+        </div>
+    );
+}
+
+/*  ⏸️ 화면 한 가운데 메시지용 컴포넌트 */
+function FullMsg({ children }) {
+    return (
+        <div className="min-h-screen flex items-center justify-center">
+            <p>{children}</p>
         </div>
     );
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6284,6 +6284,11 @@ jsonpointer@^5.0.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz"

--- a/point/src/main/java/aivlecloudnative/domain/Point.java
+++ b/point/src/main/java/aivlecloudnative/domain/Point.java
@@ -21,12 +21,12 @@ public class Point {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 포인트 고유 ID
 
-    private String userId;
+    private Long userId;
     private Long currentPoints;
     private Boolean isKTmember;
 
     // 초기 포인트 지급을 위한 팩토리 메서드
-    public static Point createInitialPoint(String userId, boolean isKTmember) {
+    public static Point createInitialPoint(Long userId, boolean isKTmember) {
         return Point.builder()
                 .userId(userId)
                 .currentPoints(isKTmember ? 5000L : 1000L) // KT 고객 5000, 일반 1000

--- a/point/src/main/java/aivlecloudnative/domain/PointQueryResponse.java
+++ b/point/src/main/java/aivlecloudnative/domain/PointQueryResponse.java
@@ -13,6 +13,6 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class PointQueryResponse {
     private Long id;          // 포인트 고유 ID
-    private String userId;    // 사용자 ID
+    private Long userId;    // 사용자 ID
     private Long currentPoints; // 현재 포인트
 }

--- a/point/src/main/java/aivlecloudnative/domain/PointRepository.java
+++ b/point/src/main/java/aivlecloudnative/domain/PointRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PointRepository extends JpaRepository<Point, Long> { // String에서 Long으로 변경
-    Optional<Point> findByUserId(String userId);
+    Optional<Point> findByUserId(Long userId);
 }

--- a/point/src/main/java/aivlecloudnative/domain/PointsGranted.java
+++ b/point/src/main/java/aivlecloudnative/domain/PointsGranted.java
@@ -15,5 +15,5 @@ public class PointsGranted extends AbstractEvent {
     private Long id;
     private Long currentPoints;
     private Long grantedPoints;
-    private String userId;
+    private Long userId;
 }

--- a/point/src/main/java/aivlecloudnative/domain/UserSignedUp.java
+++ b/point/src/main/java/aivlecloudnative/domain/UserSignedUp.java
@@ -1,19 +1,23 @@
 package aivlecloudnative.domain;
 
 import aivlecloudnative.infra.AbstractEvent;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties; // 추가
+import lombok.*;
 
-@Getter
-@Setter
+//<<< DDD / Domain Event
+@EqualsAndHashCode(callSuper = false)
+@Data
 @ToString
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserSignedUp extends AbstractEvent {
-    private String userId;
+
+    private Long userId;
     private String email;
     private String userName;
     private String message;
-    private Boolean isKT;
+    private Boolean isKt;
+    private Boolean isAuthor;
+
+    public UserSignedUp() {
+        super();
+    }
 }
+//>>> DDD / Domain Event

--- a/point/src/main/java/aivlecloudnative/infra/AbstractEvent.java
+++ b/point/src/main/java/aivlecloudnative/infra/AbstractEvent.java
@@ -7,14 +7,12 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Setter
 @ToString
 public abstract class AbstractEvent {
     private String eventType;
-    private LocalDateTime timestamp;
+    private Long timestamp;
 
     // ObjectMapper 인스턴스를 static final로 선언하여 재사용
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -26,7 +24,7 @@ public abstract class AbstractEvent {
 
     public AbstractEvent() {
         this.eventType = this.getClass().getSimpleName();
-        this.timestamp = LocalDateTime.now();
+        this.timestamp = System.currentTimeMillis();
     }
 
     // 모든 하위 클래스가 사용할 toJson 메서드

--- a/point/src/main/java/aivlecloudnative/infra/PointController.java
+++ b/point/src/main/java/aivlecloudnative/infra/PointController.java
@@ -28,7 +28,7 @@ public class PointController {
     public ResponseEntity<PointQueryResponse> getPointByUserId(@PathVariable String userId) {
         log.info("Attempting to retrieve points for userId: {}", userId);
 
-        return pointRepository.findByUserId(userId)
+        return pointRepository.findByUserId(Long.valueOf(userId))
                 .map(point -> {
                     PointQueryResponse response = new PointQueryResponse(
                         point.getId(),

--- a/point/src/main/java/aivlecloudnative/infra/PolicyHandler.java
+++ b/point/src/main/java/aivlecloudnative/infra/PolicyHandler.java
@@ -80,7 +80,7 @@ public class PolicyHandler {
                                 userSignedUp.getUserId(), existingPoint.getId());
                         return null;
                     } else {
-                        Point newPoint = Point.createInitialPoint(userSignedUp.getUserId(), userSignedUp.getIsKT());
+                        Point newPoint = Point.createInitialPoint(userSignedUp.getUserId(), userSignedUp.getIsKt());
                         pointRepository.save(newPoint);
                         log.info("Granted {} points to user {} (Initial Point ID: {})",
                                 newPoint.getCurrentPoints(), newPoint.getUserId(), newPoint.getId());
@@ -194,7 +194,7 @@ public class PolicyHandler {
                     }
                     Long requiredPoints = optionalBookInfo.get().getPrice();
 
-                    Optional<Point> optionalPoint = pointRepository.findByUserId(userId);
+                    Optional<Point> optionalPoint = pointRepository.findByUserId(Long.valueOf(userId));
                     if (optionalPoint.isEmpty()) {
                         log.warn("Points for userId {} not found. Cannot deduct points.", userId);
                         return null;

--- a/point/src/main/resources/application.yml
+++ b/point/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-    port: 8080
+    port: 8087
 
 spring:
   application:

--- a/user/src/main/java/aivlecloudnative/domain/AuthorAccepted.java
+++ b/user/src/main/java/aivlecloudnative/domain/AuthorAccepted.java
@@ -10,10 +10,16 @@ import lombok.ToString;
 @ToString
 public class AuthorAccepted extends AbstractEvent {
 
-    private Long id;
+    private Long id; // 승인된 Author의 PK
+    private Long userId; // 승인된 User의 고유 ID
+    private String eventType;
+    private Long timestamp;
 
-    public AuthorAccepted(Long id) {
+    public AuthorAccepted() {}
+
+    public AuthorAccepted(Long id, Long userId) {
         this.id = id;
+        this.userId = userId;
     }
 }
 

--- a/user/src/main/java/aivlecloudnative/domain/LoginResponse.java
+++ b/user/src/main/java/aivlecloudnative/domain/LoginResponse.java
@@ -3,8 +3,5 @@ package aivlecloudnative.domain;
 public record LoginResponse(
         String accessToken,
         String tokenType,
-        Long userId,
-        String email,
-        boolean isAuthor,
-        boolean isAdmin
+        String userName
 ) {}

--- a/user/src/main/java/aivlecloudnative/domain/SignUpResponse.java
+++ b/user/src/main/java/aivlecloudnative/domain/SignUpResponse.java
@@ -1,0 +1,7 @@
+package aivlecloudnative.domain;
+
+public record SignUpResponse(
+        Long userId,
+        String email,
+        String username
+) {}

--- a/user/src/main/java/aivlecloudnative/infra/JwtTokenProvider.java
+++ b/user/src/main/java/aivlecloudnative/infra/JwtTokenProvider.java
@@ -22,18 +22,22 @@ public class JwtTokenProvider {
     private String secretKey;
     private final long validityMs = 60 * 60 * 1000; // 1 시간
 
-    public String createToken(Long userId, Collection<String> roles) {
+    public String createToken(Long userId, String email, boolean isAuthor, boolean isAdmin) {
         Date now = new Date();
         Date exp = new Date(now.getTime() + validityMs);
 
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
-                .claim("roles", roles)
+                .claim("userId", userId)
+                .claim("email", email)
+                .claim("isAuthor", isAuthor)
+                .claim("isAdmin", isAdmin)
                 .setIssuedAt(now)
                 .setExpiration(exp)
                 .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
                 .compact();
     }
+
 
     public boolean validate(String token) {
         try {

--- a/user/src/main/java/aivlecloudnative/infra/UserController.java
+++ b/user/src/main/java/aivlecloudnative/infra/UserController.java
@@ -20,7 +20,7 @@ public class UserController {
 
     /* ---------- 회원가입 ---------- */
     @PostMapping("/signup")
-    public User signUp(@RequestBody @Valid SignUpCommand cmd) {
+    public SignUpResponse signUp(@RequestBody @Valid SignUpCommand cmd) {
         return userService.signUp(cmd);
     }
 

--- a/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
+++ b/user/src/test/java/aivlecloudnative/signUp/UserControllerTest.java
@@ -89,10 +89,8 @@ class UserControllerTest {
         LoginResponse response = new LoginResponse(
                 "mock-token",
                 "Bearer",
-                1L,
-                "user@example.com",
-                false,
-                false
+                "test"
+
         );
 
         Mockito.when(userService.login(any(LoginCommand.class)))


### PR DESCRIPTION
## ✨ 작가 신청/승인, 도서 필터링, 포인트 연동 기능 구현

### 📌 주요 변경사항

#### ✅ 작가 신청 및 관리자 승인 기능 API 연동
- 일반 사용자가 **작가 신청** 가능
  - 관련 API 연동 완료 (`POST /authors/apply`)
- 관리자는 **작가 승인/거절** 기능 수행 가능
  - 승인 시 해당 유저의 작가 권한 부여
  - 승인된 작가는 원고 등록 등 작가 기능 사용 가능

#### ✅ 로그인 사용자 기반 도서 필터링 적용
- 로그인된 사용자의 권한에 따라 열람 가능한 도서 목록 필터링
  - 예: 일반 유저는 출간된 도서만, 로그인한 경우 열람한 도서 필터링 능

#### ✅ 원고 조회 화면에서 등록 기능 추가
- 작가 전용 원고 리스트 화면에서 **[원고 등록] 버튼** 추가
  - 클릭 시 신규 원고 작성 화면으로 이동 가능

#### ✅ 포인트 정보 연동 및 KT 여부 기반 업데이트
- 마이페이지에 **실시간 포인트 정보 연동**
- 사용자의 **KT 여부에 따라 포인트 지급 방식 다르게 처리**
  - KT 사용자의 경우 별도 포인트 로직 적용

---

### 🧪 테스트 및 확인 사항
- 작가 신청 → 관리자 승인 흐름 정상 작동 확인
- 권한별 도서 필터링 및 원고 접근 제한 동작 테스트
- 포인트 정보가 마이페이지에 정상 반영되는지 확인